### PR TITLE
JS Encoding Signature

### DIFF
--- a/v2/js/search.html
+++ b/v2/js/search.html
@@ -46,6 +46,7 @@ OAuth.setTimestampAndNonce(message);
 OAuth.SignatureMethod.sign(message, accessor);
 
 var parameterMap = OAuth.getParameterMap(message.parameters);
+parameterMap.oauth_signature = parameterMap.oauth_signature.replace(/\+/g,'%2B');
 console.log(parameterMap);
 
 $.ajax({


### PR DESCRIPTION
Although the OAuth signature is created correctly, we need to encode any '+' characters.  The '+' characters are reserved characters in URIs.  If the '+' is present in a signature you will receive a 400 server response.
