### PR TITLE
jQuery post 1.4.4 places the '_' variable which causes the yelp api to re

### DIFF
--- a/v2/js/search.html
+++ b/v2/js/search.html
@@ -1,7 +1,7 @@
 <html> 
 <head> 
 <title>Yelp OAuth Example</title> 
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"></script> 
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script> 
 <script type="text/javascript" src="http://oauth.googlecode.com/svn/code/javascript/oauth.js"></script>
 <script type="text/javascript" src="http://oauth.googlecode.com/svn/code/javascript/sha1.js"></script>
 <script type="text/javascript" src="https://github.com/jamespadolsey/prettyPrint.js/raw/master/prettyprint.js"></script>
@@ -51,6 +51,7 @@ console.log(parameterMap);
 $.ajax({
   'url': message.action,
   'data': parameterMap,
+  'cache':true,
   'dataType': 'jsonp',
   'jsonpCallback': 'cb',
   'success': function(data, textStats, XMLHttpRequest) {


### PR DESCRIPTION
jQuery post 1.4.4 places the '_' variable which causes the yelp api to return an error indicating that the "Signature" is invalid.  Setting the cache to true resolves this issue. (**shaking fist in air**)
