### PR TITLE
Solve a signature error in csharp sample

### DIFF
--- a/v2/csharp/YelpAPI/Program.cs
+++ b/v2/csharp/YelpAPI/Program.cs
@@ -91,7 +91,7 @@ namespace YelpAPI
 
             foreach (var queryParam in queryParams)
             {
-                query[queryParam.Key] = SimpleOAuth.Utilities.UrlHelper.Encode(queryParam.Value);
+                query[queryParam.Key] = queryParam.Value;
             }
 
             var uriBuilder = new UriBuilder(baseURL);


### PR DESCRIPTION
I'm getting an oauth signature error with requests generated by the c# sample. SimpleOAuth.Utilities.UrlHelper.Encode seems to be leading to double url encoding, and one possible fix that works for me is to remove it. Eg - $query.ToString() returns location=San+Francisco%2c+CA (so, already url encoded) in the below.

PS C:> add-type -assemblyname system.web
PS C:> $query = [Web.HttpUtility]::ParseQueryString("")
PS C:> $query["location"] = "San Francisco, CA"
PS C:> $query.ToString()
location=San+Francisco%2c+CA
PS C:> $uriBuilder = new-object UriBuilder("http://foo")
PS C:> $uriBuilder.Query = $query.ToString()
PS C:> $uriBuilder.ToString()
http://foo:80/?location=San+Francisco%2c+CA
