### PR TITLE
Allowing ARC with v2 objective-c version 

### DIFF
--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/AppDelegate.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  YelpAPI-IsolationTestAutoMemory
+//
+//  Created by Terry Bu on 11/7/14.
+//  Copyright (c) 2014 TerryBuOrganization. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/AppDelegate.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/AppDelegate.m
@@ -1,0 +1,45 @@
+//
+//  AppDelegate.m
+//  YelpAPI-IsolationTestAutoMemory
+//
+//  Created by Terry Bu on 11/7/14.
+//  Copyright (c) 2014 TerryBuOrganization. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Base.lproj/LaunchScreen.xib
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 TerryBuOrganization. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="YelpAPISampleARCAllowed" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Base.lproj/Main.storyboard
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Info.plist
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>TerryBuIdentifier.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/NSURLRequest+OAuth.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/NSURLRequest+OAuth.h
@@ -1,0 +1,28 @@
+//
+//  NSURLRequest+OAuth.h
+//  YelpAPISample
+//
+//  Created by Thibaud Robelain on 7/2/14.
+//  Copyright (c) 2014 Yelp Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSURLRequest (OAuth)
+
+/**
+ @param host The domain host
+ @param path The path on the domain host
+ @return Builds a NSURLRequest with all the OAuth headers field set with the host and path given to it.
+ */
++ (NSURLRequest *)requestWithHost:(NSString *)host path:(NSString *)path;
+
+/**
+ @param host The domain host
+ @param path The path on the domain host
+ @param params The query parameters
+ @return Builds a NSURLRequest with all the OAuth headers field set with the host, path, and query parameters given to it.
+ */
++ (NSURLRequest *)requestWithHost:(NSString *)host path:(NSString *)path params:(NSDictionary *)params;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/NSURLRequest+OAuth.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/NSURLRequest+OAuth.m
@@ -1,0 +1,70 @@
+//
+//  NSURLRequest+OAuth.m
+//  YelpAPISample
+//
+//  Created by Thibaud Robelain on 7/2/14.
+//  Copyright (c) 2014 Yelp Inc. All rights reserved.
+//
+
+#import "NSURLRequest+OAuth.h"
+#import "OAMutableURLRequest.h"
+#import "YPAPISample.h"
+#import "YourKeysAndTokens.h"
+
+/**
+ OAuth credential placeholders that must be filled by each user in regards to
+ http://www.yelp.com/developers/getting_started/api_access
+ */
+
+@implementation NSURLRequest (OAuth)
+
++ (NSURLRequest *)requestWithHost:(NSString *)host path:(NSString *)path {
+  return [self requestWithHost:host path:path params:nil];
+}
+
++ (NSURLRequest *)requestWithHost:(NSString *)host path:(NSString *)path params:(NSDictionary *)params {
+  NSURL *URL = [self _URLWithHost:host path:path queryParameters:params];
+
+  if ([kConsumerKey length] == 0 || [kConsumerSecret length] == 0 || [kToken length] == 0 || [kTokenSecret length] == 0) {
+    NSLog(@"WARNING: Please enter your api v2 credentials before attempting any API request. You can do so in NSURLRequest+OAuth.m");
+  }
+
+  OAConsumer *consumer = [[OAConsumer alloc] initWithKey:kConsumerKey secret:kConsumerSecret];
+  OAToken *token = [[OAToken alloc] initWithKey:kToken secret:kTokenSecret];
+
+  //The signature provider is HMAC-SHA1 by default and the nonce and timestamp are generated in the method
+  OAMutableURLRequest *request = [[OAMutableURLRequest alloc] initWithURL:URL consumer:consumer token:token realm:nil signatureProvider:nil];
+  [request setHTTPMethod:@"GET"];
+  [request prepare]; // Attaches our consumer and token credentials to the request
+
+  return request;
+}
+
+#pragma mark - URL Builder Helper
+
+/**
+ Builds an NSURL given a host, path and a number of queryParameters
+
+ @param host The domain host of the API
+ @param path The path of the API after the domain
+ @param params The query parameters
+ @return An NSURL built with the specified parameters
+*/
++ (NSURL *)_URLWithHost:(NSString *)host path:(NSString *)path queryParameters:(NSDictionary *)queryParameters {
+
+  NSMutableArray *queryParts = [[NSMutableArray alloc] init];
+  for (NSString *key in [queryParameters allKeys]) {
+    NSString *queryPart = [NSString stringWithFormat:@"%@=%@", key, queryParameters[key]];
+    [queryParts addObject:queryPart];
+  }
+
+  NSURLComponents *components = [[NSURLComponents alloc] init];
+  components.scheme = @"http";
+  components.host = host;
+  components.path = path;
+  components.query = [queryParts componentsJoinedByString:@"&"];
+
+  return [components URL];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSMutableURLRequest+Parameters.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSMutableURLRequest+Parameters.h
@@ -1,0 +1,37 @@
+//
+//  NSMutableURLRequest+Parameters.h
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "OARequestParameter.h"
+#import "NSURL+Base.h"
+
+
+@interface NSMutableURLRequest (OAParameterAdditions)
+
+@property(nonatomic, retain) NSArray *parameters;
+
+- (void)setHTTPBodyWithString:(NSString *)body;
+- (void)attachFileWithName:(NSString *)name filename:(NSString*)filename contentType:(NSString *)contentType data:(NSData*)data;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSMutableURLRequest+Parameters.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSMutableURLRequest+Parameters.m
@@ -81,7 +81,7 @@ static NSString *Boundary = @"-----------------------------------0xCoCoaouTHeBou
 
 - (void)setHTTPBodyWithString:(NSString *)body {
 	NSData *bodyData = [body dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
-	[self setValue:[NSString stringWithFormat:@"%d", [bodyData length]] forHTTPHeaderField:@"Content-Length"];
+	[self setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[bodyData length]] forHTTPHeaderField:@"Content-Length"];
 	[self setHTTPBody:bodyData];
 }
 

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSMutableURLRequest+Parameters.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSMutableURLRequest+Parameters.m
@@ -1,0 +1,111 @@
+//
+//  NSMutableURLRequest+Parameters.m
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "NSMutableURLRequest+Parameters.h"
+
+static NSString *Boundary = @"-----------------------------------0xCoCoaouTHeBouNDaRy"; 
+
+@implementation NSMutableURLRequest (OAParameterAdditions)
+
+- (BOOL)isMultipart {
+	return [[self valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"multipart/form-data"];
+}
+
+- (NSArray *)parameters {
+    NSString *encodedParameters = nil;
+    
+	if (![self isMultipart]) {
+		if ([[self HTTPMethod] isEqualToString:@"GET"] || [[self HTTPMethod] isEqualToString:@"DELETE"]) {
+			encodedParameters = [[self URL] query];
+		} else {
+            encodedParameters = [[NSString alloc] initWithData:[self HTTPBody] encoding:NSASCIIStringEncoding];
+		}
+	}
+    
+    if (encodedParameters == nil || [encodedParameters isEqualToString:@""]) {
+        return nil;
+    }
+//    NSLog(@"raw parameters %@", encodedParameters);
+    NSArray *encodedParameterPairs = [encodedParameters componentsSeparatedByString:@"&"];
+    NSMutableArray *requestParameters = [NSMutableArray arrayWithCapacity:[encodedParameterPairs count]];
+    
+    for (NSString *encodedPair in encodedParameterPairs) {
+        NSArray *encodedPairElements = [encodedPair componentsSeparatedByString:@"="];
+        OARequestParameter *parameter = [[OARequestParameter alloc] initWithName:[[encodedPairElements objectAtIndex:0] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]
+                                                                           value:[[encodedPairElements objectAtIndex:1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+        [requestParameters addObject:parameter];
+    }
+    
+    return requestParameters;
+}
+
+- (void)setParameters:(NSArray *)parameters
+{
+    NSMutableArray *pairs = [[NSMutableArray alloc] initWithCapacity:[parameters count]];
+	for (OARequestParameter *requestParameter in parameters) {
+		[pairs addObject:[requestParameter URLEncodedNameValuePair]];
+	}
+	
+	NSString *encodedParameterPairs = [pairs componentsJoinedByString:@"&"];
+    
+	if ([[self HTTPMethod] isEqualToString:@"GET"] || [[self HTTPMethod] isEqualToString:@"DELETE"]) {
+		[self setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", [[self URL] URLStringWithoutQuery], encodedParameterPairs]]];
+	} else {
+		// POST, PUT
+		[self setHTTPBodyWithString:encodedParameterPairs];
+		[self setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+	}
+}
+
+- (void)setHTTPBodyWithString:(NSString *)body {
+	NSData *bodyData = [body dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
+	[self setValue:[NSString stringWithFormat:@"%d", [bodyData length]] forHTTPHeaderField:@"Content-Length"];
+	[self setHTTPBody:bodyData];
+}
+
+- (void)attachFileWithName:(NSString *)name filename:(NSString*)filename contentType:(NSString *)contentType data:(NSData*)data {
+
+	NSArray *parameters = [self parameters];
+	[self setValue:[@"multipart/form-data; boundary=" stringByAppendingString:Boundary] forHTTPHeaderField:@"Content-type"];
+	
+	NSMutableData *bodyData = [NSMutableData new];
+	for (OARequestParameter *parameter in parameters) {
+		NSString *param = [NSString stringWithFormat:@"--%@\r\nContent-Disposition: form-data; name=\"%@\"\r\n\r\n%@\r\n",
+						   Boundary, [parameter URLEncodedName], [parameter value]];
+
+		[bodyData appendData:[param dataUsingEncoding:NSUTF8StringEncoding]];
+	}
+
+	NSString *filePrefix = [NSString stringWithFormat:@"--%@\r\nContent-Disposition: form-data; name=\"%@\"; filename=\"%@\"\r\nContent-Type: %@\r\n\r\n",
+		Boundary, name, filename, contentType];
+	[bodyData appendData:[filePrefix dataUsingEncoding:NSUTF8StringEncoding]];
+	[bodyData appendData:data];
+	
+	[bodyData appendData:[[[@"--" stringByAppendingString:Boundary] stringByAppendingString:@"--"] dataUsingEncoding:NSUTF8StringEncoding]];
+	[self setValue:[NSString stringWithFormat:@"%d", [bodyData length]] forHTTPHeaderField:@"Content-Length"];
+	[self setHTTPBody:bodyData];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSString+URLEncoding.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSString+URLEncoding.h
@@ -1,0 +1,35 @@
+//
+//  NSString+URLEncoding.h
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSString (OAURLEncodingAdditions)
+
+- (NSString *)encodedURLString;
+- (NSString *)encodedURLParameterString;
+- (NSString *)decodedURLString;
+- (NSString *)removeQuotes;
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSString+URLEncoding.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSString+URLEncoding.m
@@ -1,0 +1,73 @@
+//
+//  NSString+URLEncoding.m
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "NSString+URLEncoding.h"
+
+
+@implementation NSString (OAURLEncodingAdditions)
+
+- (NSString *)encodedURLString {
+	NSString *result = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
+                                                                           (CFStringRef)self,
+                                                                           NULL,                   // characters to leave unescaped (NULL = all escaped sequences are replaced)
+                                                                           CFSTR("?=&+"),          // legal URL characters to be escaped (NULL = all legal characters are replaced)
+                                                                           kCFStringEncodingUTF8)); // encoding
+	return result;
+}
+
+- (NSString *)encodedURLParameterString {
+    NSString *result = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
+                                                                           (CFStringRef)self,
+                                                                           NULL,
+                                                                           CFSTR(":/=,!$&'()*+;[]@#?"),
+                                                                           kCFStringEncodingUTF8));
+	return result;
+}
+
+- (NSString *)decodedURLString {
+	NSString *result = (NSString*)CFBridgingRelease(CFURLCreateStringByReplacingPercentEscapesUsingEncoding(kCFAllocatorDefault,
+																						  (CFStringRef)self,
+																						  CFSTR(""),
+																						  kCFStringEncodingUTF8));
+	
+	return result ;
+	
+}
+
+-(NSString *)removeQuotes
+{
+	NSUInteger length = [self length];
+	NSString *ret = self;
+	if ([self characterAtIndex:0] == '"') {
+		ret = [ret substringFromIndex:1];
+	}
+	if ([self characterAtIndex:length - 1] == '"') {
+		ret = [ret substringToIndex:length - 2];
+	}
+	
+	return ret;
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSURL+Base.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSURL+Base.h
@@ -1,0 +1,34 @@
+//
+//  NSURL+Base.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSURL (OABaseAdditions)
+
+- (NSString *)URLStringWithoutQuery;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSURL+Base.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Categories/NSURL+Base.m
@@ -1,0 +1,37 @@
+//
+//  NSURL+Base.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "NSURL+Base.h"
+
+
+@implementation NSURL (OABaseAdditions)
+
+- (NSString *)URLStringWithoutQuery {
+    NSArray *parts = [[self absoluteString] componentsSeparatedByString:@"?"];
+    return [parts objectAtIndex:0];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/Base64Transcoder.c
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/Base64Transcoder.c
@@ -1,0 +1,230 @@
+/*
+ *  Base64Transcoder.c
+ *  Base64Test
+ *
+ *  Created by Jonathan Wight on Tue Mar 18 2003.
+ *  Copyright (c) 2003 Toxic Software. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+#include "Base64Transcoder.h"
+
+#include <math.h>
+#include <string.h>
+
+const u_int8_t kBase64EncodeTable[64] = {
+	/*  0 */ 'A',	/*  1 */ 'B',	/*  2 */ 'C',	/*  3 */ 'D', 
+	/*  4 */ 'E',	/*  5 */ 'F',	/*  6 */ 'G',	/*  7 */ 'H', 
+	/*  8 */ 'I',	/*  9 */ 'J',	/* 10 */ 'K',	/* 11 */ 'L', 
+	/* 12 */ 'M',	/* 13 */ 'N',	/* 14 */ 'O',	/* 15 */ 'P', 
+	/* 16 */ 'Q',	/* 17 */ 'R',	/* 18 */ 'S',	/* 19 */ 'T', 
+	/* 20 */ 'U',	/* 21 */ 'V',	/* 22 */ 'W',	/* 23 */ 'X', 
+	/* 24 */ 'Y',	/* 25 */ 'Z',	/* 26 */ 'a',	/* 27 */ 'b', 
+	/* 28 */ 'c',	/* 29 */ 'd',	/* 30 */ 'e',	/* 31 */ 'f', 
+	/* 32 */ 'g',	/* 33 */ 'h',	/* 34 */ 'i',	/* 35 */ 'j', 
+	/* 36 */ 'k',	/* 37 */ 'l',	/* 38 */ 'm',	/* 39 */ 'n', 
+	/* 40 */ 'o',	/* 41 */ 'p',	/* 42 */ 'q',	/* 43 */ 'r', 
+	/* 44 */ 's',	/* 45 */ 't',	/* 46 */ 'u',	/* 47 */ 'v', 
+	/* 48 */ 'w',	/* 49 */ 'x',	/* 50 */ 'y',	/* 51 */ 'z', 
+	/* 52 */ '0',	/* 53 */ '1',	/* 54 */ '2',	/* 55 */ '3', 
+	/* 56 */ '4',	/* 57 */ '5',	/* 58 */ '6',	/* 59 */ '7', 
+	/* 60 */ '8',	/* 61 */ '9',	/* 62 */ '+',	/* 63 */ '/'
+};
+
+/*
+-1 = Base64 end of data marker.
+-2 = White space (tabs, cr, lf, space)
+-3 = Noise (all non whitespace, non-base64 characters) 
+-4 = Dangerous noise
+-5 = Illegal noise (null byte)
+*/
+
+const int8_t kBase64DecodeTable[128] = {
+	/* 0x00 */ -5, 	/* 0x01 */ -3, 	/* 0x02 */ -3, 	/* 0x03 */ -3,
+	/* 0x04 */ -3, 	/* 0x05 */ -3, 	/* 0x06 */ -3, 	/* 0x07 */ -3,
+	/* 0x08 */ -3, 	/* 0x09 */ -2, 	/* 0x0a */ -2, 	/* 0x0b */ -2,
+	/* 0x0c */ -2, 	/* 0x0d */ -2, 	/* 0x0e */ -3, 	/* 0x0f */ -3,
+	/* 0x10 */ -3, 	/* 0x11 */ -3, 	/* 0x12 */ -3, 	/* 0x13 */ -3,
+	/* 0x14 */ -3, 	/* 0x15 */ -3, 	/* 0x16 */ -3, 	/* 0x17 */ -3,
+	/* 0x18 */ -3, 	/* 0x19 */ -3, 	/* 0x1a */ -3, 	/* 0x1b */ -3,
+	/* 0x1c */ -3, 	/* 0x1d */ -3, 	/* 0x1e */ -3, 	/* 0x1f */ -3,
+	/* ' ' */ -2,	/* '!' */ -3,	/* '"' */ -3,	/* '#' */ -3,
+	/* '$' */ -3,	/* '%' */ -3,	/* '&' */ -3,	/* ''' */ -3,
+	/* '(' */ -3,	/* ')' */ -3,	/* '*' */ -3,	/* '+' */ 62,
+	/* ',' */ -3,	/* '-' */ -3,	/* '.' */ -3,	/* '/' */ 63,
+	/* '0' */ 52,	/* '1' */ 53,	/* '2' */ 54,	/* '3' */ 55,
+	/* '4' */ 56,	/* '5' */ 57,	/* '6' */ 58,	/* '7' */ 59,
+	/* '8' */ 60,	/* '9' */ 61,	/* ':' */ -3,	/* ';' */ -3,
+	/* '<' */ -3,	/* '=' */ -1,	/* '>' */ -3,	/* '?' */ -3,
+	/* '@' */ -3,	/* 'A' */ 0,	/* 'B' */  1,	/* 'C' */  2,
+	/* 'D' */  3,	/* 'E' */  4,	/* 'F' */  5,	/* 'G' */  6,
+	/* 'H' */  7,	/* 'I' */  8,	/* 'J' */  9,	/* 'K' */ 10,
+	/* 'L' */ 11,	/* 'M' */ 12,	/* 'N' */ 13,	/* 'O' */ 14,
+	/* 'P' */ 15,	/* 'Q' */ 16,	/* 'R' */ 17,	/* 'S' */ 18,
+	/* 'T' */ 19,	/* 'U' */ 20,	/* 'V' */ 21,	/* 'W' */ 22,
+	/* 'X' */ 23,	/* 'Y' */ 24,	/* 'Z' */ 25,	/* '[' */ -3,
+	/* '\' */ -3,	/* ']' */ -3,	/* '^' */ -3,	/* '_' */ -3,
+	/* '`' */ -3,	/* 'a' */ 26,	/* 'b' */ 27,	/* 'c' */ 28,
+	/* 'd' */ 29,	/* 'e' */ 30,	/* 'f' */ 31,	/* 'g' */ 32,
+	/* 'h' */ 33,	/* 'i' */ 34,	/* 'j' */ 35,	/* 'k' */ 36,
+	/* 'l' */ 37,	/* 'm' */ 38,	/* 'n' */ 39,	/* 'o' */ 40,
+	/* 'p' */ 41,	/* 'q' */ 42,	/* 'r' */ 43,	/* 's' */ 44,
+	/* 't' */ 45,	/* 'u' */ 46,	/* 'v' */ 47,	/* 'w' */ 48,
+	/* 'x' */ 49,	/* 'y' */ 50,	/* 'z' */ 51,	/* '{' */ -3,
+	/* '|' */ -3,	/* '}' */ -3,	/* '~' */ -3,	/* 0x7f */ -3
+};
+
+const u_int8_t kBits_00000011 = 0x03;
+const u_int8_t kBits_00001111 = 0x0F;
+const u_int8_t kBits_00110000 = 0x30;
+const u_int8_t kBits_00111100 = 0x3C;
+const u_int8_t kBits_00111111 = 0x3F;
+const u_int8_t kBits_11000000 = 0xC0;
+const u_int8_t kBits_11110000 = 0xF0;
+const u_int8_t kBits_11111100 = 0xFC;
+
+size_t EstimateBas64EncodedDataSize(size_t inDataSize)
+{
+size_t theEncodedDataSize = (int)ceil(inDataSize / 3.0) * 4;
+theEncodedDataSize = theEncodedDataSize / 72 * 74 + theEncodedDataSize % 72;
+return(theEncodedDataSize);
+}
+
+size_t EstimateBas64DecodedDataSize(size_t inDataSize)
+{
+size_t theDecodedDataSize = (int)ceil(inDataSize / 4.0) * 3;
+//theDecodedDataSize = theDecodedDataSize / 72 * 74 + theDecodedDataSize % 72;
+return(theDecodedDataSize);
+}
+
+bool Base64EncodeData(const void *inInputData, size_t inInputDataSize, char *outOutputData, size_t *ioOutputDataSize)
+{
+size_t theEncodedDataSize = EstimateBas64EncodedDataSize(inInputDataSize);
+if (*ioOutputDataSize < theEncodedDataSize)
+	return(false);
+*ioOutputDataSize = theEncodedDataSize;
+const u_int8_t *theInPtr = (const u_int8_t *)inInputData;
+u_int32_t theInIndex = 0, theOutIndex = 0;
+for (; theInIndex < (inInputDataSize / 3) * 3; theInIndex += 3)
+	{
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex] & kBits_11111100) >> 2];
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex] & kBits_00000011) << 4 | (theInPtr[theInIndex + 1] & kBits_11110000) >> 4];
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex + 1] & kBits_00001111) << 2 | (theInPtr[theInIndex + 2] & kBits_11000000) >> 6];
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex + 2] & kBits_00111111) >> 0];
+	if (theOutIndex % 74 == 72)
+		{
+		outOutputData[theOutIndex++] = '\r';
+		outOutputData[theOutIndex++] = '\n';
+		}
+	}
+const size_t theRemainingBytes = inInputDataSize - theInIndex;
+if (theRemainingBytes == 1)
+	{
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex] & kBits_11111100) >> 2];
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex] & kBits_00000011) << 4 | (0 & kBits_11110000) >> 4];
+	outOutputData[theOutIndex++] = '=';
+	outOutputData[theOutIndex++] = '=';
+	if (theOutIndex % 74 == 72)
+		{
+		outOutputData[theOutIndex++] = '\r';
+		outOutputData[theOutIndex++] = '\n';
+		}
+	}
+else if (theRemainingBytes == 2)
+	{
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex] & kBits_11111100) >> 2];
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex] & kBits_00000011) << 4 | (theInPtr[theInIndex + 1] & kBits_11110000) >> 4];
+	outOutputData[theOutIndex++] = kBase64EncodeTable[(theInPtr[theInIndex + 1] & kBits_00001111) << 2 | (0 & kBits_11000000) >> 6];
+	outOutputData[theOutIndex++] = '=';
+	if (theOutIndex % 74 == 72)
+		{
+		outOutputData[theOutIndex++] = '\r';
+		outOutputData[theOutIndex++] = '\n';
+		}
+	}
+return(true);
+}
+
+bool Base64DecodeData(const void *inInputData, size_t inInputDataSize, void *ioOutputData, size_t *ioOutputDataSize)
+{
+memset(ioOutputData, '.', *ioOutputDataSize);
+
+size_t theDecodedDataSize = EstimateBas64DecodedDataSize(inInputDataSize);
+if (*ioOutputDataSize < theDecodedDataSize)
+	return(false);
+*ioOutputDataSize = 0;
+const u_int8_t *theInPtr = (const u_int8_t *)inInputData;
+u_int8_t *theOutPtr = (u_int8_t *)ioOutputData;
+size_t theInIndex = 0, theOutIndex = 0;
+u_int8_t theOutputOctet;
+size_t theSequence = 0;
+for (; theInIndex < inInputDataSize; )
+	{
+	int8_t theSextet = 0;
+	
+	int8_t theCurrentInputOctet = theInPtr[theInIndex];
+	theSextet = kBase64DecodeTable[theCurrentInputOctet];
+	if (theSextet == -1)
+		break;
+	while (theSextet == -2)
+		{
+		theCurrentInputOctet = theInPtr[++theInIndex];
+		theSextet = kBase64DecodeTable[theCurrentInputOctet];
+		}
+	while (theSextet == -3)
+		{
+		theCurrentInputOctet = theInPtr[++theInIndex];
+		theSextet = kBase64DecodeTable[theCurrentInputOctet];
+		}
+	if (theSequence == 0)
+		{
+		theOutputOctet = (theSextet >= 0 ? theSextet : 0) << 2 & kBits_11111100;
+		}
+	else if (theSequence == 1)
+		{
+		theOutputOctet |= (theSextet >- 0 ? theSextet : 0) >> 4 & kBits_00000011;
+		theOutPtr[theOutIndex++] = theOutputOctet;
+		}
+	else if (theSequence == 2)
+		{
+		theOutputOctet = (theSextet >= 0 ? theSextet : 0) << 4 & kBits_11110000;
+		}
+	else if (theSequence == 3)
+		{
+		theOutputOctet |= (theSextet >= 0 ? theSextet : 0) >> 2 & kBits_00001111;
+		theOutPtr[theOutIndex++] = theOutputOctet;
+		}
+	else if (theSequence == 4)
+		{
+		theOutputOctet = (theSextet >= 0 ? theSextet : 0) << 6 & kBits_11000000;
+		}
+	else if (theSequence == 5)
+		{
+		theOutputOctet |= (theSextet >= 0 ? theSextet : 0) >> 0 & kBits_00111111;
+		theOutPtr[theOutIndex++] = theOutputOctet;
+		}
+	theSequence = (theSequence + 1) % 6;
+	if (theSequence != 2 && theSequence != 4)
+		theInIndex++;
+	}
+*ioOutputDataSize = theOutIndex;
+return(true);
+}

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/Base64Transcoder.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/Base64Transcoder.h
@@ -1,0 +1,36 @@
+/*
+ *  Base64Transcoder.h
+ *  Base64Test
+ *
+ *  Created by Jonathan Wight on Tue Mar 18 2003.
+ *  Copyright (c) 2003 Toxic Software. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+extern size_t EstimateBas64EncodedDataSize(size_t inDataSize);
+extern size_t EstimateBas64DecodedDataSize(size_t inDataSize);
+
+extern bool Base64EncodeData(const void *inInputData, size_t inInputDataSize, char *outOutputData, size_t *ioOutputDataSize);
+extern bool Base64DecodeData(const void *inInputData, size_t inInputDataSize, void *ioOutputData, size_t *ioOutputDataSize);
+

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/hmac.c
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/hmac.c
@@ -1,0 +1,86 @@
+//
+//  hmac.c
+//  OAuthConsumer
+//
+//  Created by Jonathan Wight on 4/8/8.
+//  Copyright 2008 Jonathan Wight. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+/*
+ * Implementation of HMAC-SHA1. Adapted from example at http://tools.ietf.org/html/rfc2104
+ 
+ */
+
+#include "sha1.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void hmac_sha1(const u_int8_t *inText, size_t inTextLength, u_int8_t* inKey, size_t inKeyLength, u_int8_t *outDigest)
+{
+#define B 64
+#define L 20
+
+SHA1_CTX theSHA1Context;
+u_int8_t k_ipad[B + 1]; /* inner padding - key XORd with ipad */
+u_int8_t k_opad[B + 1]; /* outer padding - key XORd with opad */
+
+/* if key is longer than 64 bytes reset it to key=SHA1 (key) */
+if (inKeyLength > B)
+	{
+	SHA1Init(&theSHA1Context);
+	SHA1Update(&theSHA1Context, inKey, inKeyLength);
+	SHA1Final(inKey, &theSHA1Context);
+	inKeyLength = L;
+	}
+
+/* start out by storing key in pads */
+memset(k_ipad, 0, sizeof k_ipad);
+memset(k_opad, 0, sizeof k_opad);
+memcpy(k_ipad, inKey, inKeyLength);
+memcpy(k_opad, inKey, inKeyLength);
+
+/* XOR key with ipad and opad values */
+int i;
+for (i = 0; i < B; i++)
+	{
+	k_ipad[i] ^= 0x36;
+	k_opad[i] ^= 0x5c;
+	}
+	
+/*
+* perform inner SHA1
+*/
+SHA1Init(&theSHA1Context);                 /* init context for 1st pass */
+SHA1Update(&theSHA1Context, k_ipad, B);     /* start with inner pad */
+SHA1Update(&theSHA1Context, (u_int8_t *)inText, inTextLength); /* then text of datagram */
+SHA1Final((u_int8_t *)outDigest, &theSHA1Context);                /* finish up 1st pass */
+
+/*
+* perform outer SHA1
+*/
+SHA1Init(&theSHA1Context);                   /* init context for 2nd
+* pass */
+SHA1Update(&theSHA1Context, k_opad, B);     /* start with outer pad */
+SHA1Update(&theSHA1Context, (u_int8_t *)outDigest, L);     /* then results of 1st
+* hash */
+SHA1Final((u_int8_t *)outDigest, &theSHA1Context);          /* finish up 2nd pass */
+
+}

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/hmac.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/hmac.h
@@ -1,0 +1,31 @@
+//
+//  hmac.h
+//  OAuthConsumer
+//
+//  Created by Jonathan Wight on 4/8/8.
+//  Copyright 2008 Jonathan Wight. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#ifndef HMAC_H
+#define HMAC_H 1
+
+extern void hmac_sha1(const u_int8_t *inText, size_t inTextLength, u_int8_t* inKey, const size_t inKeyLength, u_int8_t *outDigest);
+
+#endif /* HMAC_H */

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/sha1.c
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/sha1.c
@@ -1,0 +1,169 @@
+/*
+SHA-1 in C
+By Steve Reid <steve@edmweb.com>
+100% Public Domain
+
+Test Vectors (from FIPS PUB 180-1)
+"abc"
+  A9993E36 4706816A BA3E2571 7850C26C 9CD0D89D
+"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+  84983E44 1C3BD26E BAAE4AA1 F95129E5 E54670F1
+A million repetitions of "a"
+  34AA973C D4C4DAA4 F61EEB2B DBAD2731 6534016F
+*/
+
+/* #define LITTLE_ENDIAN * This should be #define'd if true. */
+#if __LITTLE_ENDIAN__
+#define LITTLE_ENDIAN
+#endif 
+/* #define SHA1HANDSOFF * Copies data before messing with it. */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "sha1.h"
+
+void SHA1Transform(u_int32_t state[5], u_int8_t buffer[64]);
+
+#define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
+
+/* blk0() and blk() perform the initial expand. */
+/* I got the idea of expanding during the round function from SSLeay */
+#ifdef LITTLE_ENDIAN
+#define blk0(i) (block->l[i] = (rol(block->l[i],24)&0xFF00FF00) \
+    |(rol(block->l[i],8)&0x00FF00FF))
+#else
+#define blk0(i) block->l[i]
+#endif
+#define blk(i) (block->l[i&15] = rol(block->l[(i+13)&15]^block->l[(i+8)&15] \
+    ^block->l[(i+2)&15]^block->l[i&15],1))
+
+/* (R0+R1), R2, R3, R4 are the different operations used in SHA1 */
+#define R0(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk0(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R1(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R2(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0x6ED9EBA1+rol(v,5);w=rol(w,30);
+#define R3(v,w,x,y,z,i) z+=(((w|x)&y)|(w&x))+blk(i)+0x8F1BBCDC+rol(v,5);w=rol(w,30);
+#define R4(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0xCA62C1D6+rol(v,5);w=rol(w,30);
+
+
+/* Hash a single 512-bit block. This is the core of the algorithm. */
+
+void SHA1Transform(u_int32_t state[5], u_int8_t buffer[64])
+{
+u_int32_t a, b, c, d, e;
+typedef union {
+    u_int8_t c[64];
+    u_int32_t l[16];
+} CHAR64LONG16;
+CHAR64LONG16* block;
+#ifdef SHA1HANDSOFF
+static u_int8_t workspace[64];
+    block = (CHAR64LONG16*)workspace;
+    memcpy(block, buffer, 64);
+#else
+    block = (CHAR64LONG16*)buffer;
+#endif
+    /* Copy context->state[] to working vars */
+    a = state[0];
+    b = state[1];
+    c = state[2];
+    d = state[3];
+    e = state[4];
+    /* 4 rounds of 20 operations each. Loop unrolled. */
+    R0(a,b,c,d,e, 0); R0(e,a,b,c,d, 1); R0(d,e,a,b,c, 2); R0(c,d,e,a,b, 3);
+    R0(b,c,d,e,a, 4); R0(a,b,c,d,e, 5); R0(e,a,b,c,d, 6); R0(d,e,a,b,c, 7);
+    R0(c,d,e,a,b, 8); R0(b,c,d,e,a, 9); R0(a,b,c,d,e,10); R0(e,a,b,c,d,11);
+    R0(d,e,a,b,c,12); R0(c,d,e,a,b,13); R0(b,c,d,e,a,14); R0(a,b,c,d,e,15);
+    R1(e,a,b,c,d,16); R1(d,e,a,b,c,17); R1(c,d,e,a,b,18); R1(b,c,d,e,a,19);
+    R2(a,b,c,d,e,20); R2(e,a,b,c,d,21); R2(d,e,a,b,c,22); R2(c,d,e,a,b,23);
+    R2(b,c,d,e,a,24); R2(a,b,c,d,e,25); R2(e,a,b,c,d,26); R2(d,e,a,b,c,27);
+    R2(c,d,e,a,b,28); R2(b,c,d,e,a,29); R2(a,b,c,d,e,30); R2(e,a,b,c,d,31);
+    R2(d,e,a,b,c,32); R2(c,d,e,a,b,33); R2(b,c,d,e,a,34); R2(a,b,c,d,e,35);
+    R2(e,a,b,c,d,36); R2(d,e,a,b,c,37); R2(c,d,e,a,b,38); R2(b,c,d,e,a,39);
+    R3(a,b,c,d,e,40); R3(e,a,b,c,d,41); R3(d,e,a,b,c,42); R3(c,d,e,a,b,43);
+    R3(b,c,d,e,a,44); R3(a,b,c,d,e,45); R3(e,a,b,c,d,46); R3(d,e,a,b,c,47);
+    R3(c,d,e,a,b,48); R3(b,c,d,e,a,49); R3(a,b,c,d,e,50); R3(e,a,b,c,d,51);
+    R3(d,e,a,b,c,52); R3(c,d,e,a,b,53); R3(b,c,d,e,a,54); R3(a,b,c,d,e,55);
+    R3(e,a,b,c,d,56); R3(d,e,a,b,c,57); R3(c,d,e,a,b,58); R3(b,c,d,e,a,59);
+    R4(a,b,c,d,e,60); R4(e,a,b,c,d,61); R4(d,e,a,b,c,62); R4(c,d,e,a,b,63);
+    R4(b,c,d,e,a,64); R4(a,b,c,d,e,65); R4(e,a,b,c,d,66); R4(d,e,a,b,c,67);
+    R4(c,d,e,a,b,68); R4(b,c,d,e,a,69); R4(a,b,c,d,e,70); R4(e,a,b,c,d,71);
+    R4(d,e,a,b,c,72); R4(c,d,e,a,b,73); R4(b,c,d,e,a,74); R4(a,b,c,d,e,75);
+    R4(e,a,b,c,d,76); R4(d,e,a,b,c,77); R4(c,d,e,a,b,78); R4(b,c,d,e,a,79);
+    /* Add the working vars back into context.state[] */
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    /* Wipe variables */
+    a = b = c = d = e = 0;
+}
+
+
+/* SHA1Init - Initialize new context */
+
+void SHA1Init(SHA1_CTX* context)
+{
+    /* SHA1 initialization constants */
+    context->state[0] = 0x67452301;
+    context->state[1] = 0xEFCDAB89;
+    context->state[2] = 0x98BADCFE;
+    context->state[3] = 0x10325476;
+    context->state[4] = 0xC3D2E1F0;
+    context->count[0] = context->count[1] = 0;
+}
+
+
+/* Run your data through this. */
+
+void SHA1Update(SHA1_CTX* context, u_int8_t* data, unsigned int len)
+{
+unsigned int i, j;
+
+    j = (context->count[0] >> 3) & 63;
+    if ((context->count[0] += len << 3) < (len << 3)) context->count[1]++;
+    context->count[1] += (len >> 29);
+    if ((j + len) > 63) {
+        memcpy(&context->buffer[j], data, (i = 64-j));
+        SHA1Transform(context->state, context->buffer);
+        for ( ; i + 63 < len; i += 64) {
+            SHA1Transform(context->state, &data[i]);
+        }
+        j = 0;
+    }
+    else i = 0;
+    memcpy(&context->buffer[j], &data[i], len - i);
+}
+
+
+/* Add padding and return the message digest. */
+
+void SHA1Final(u_int8_t digest[20], SHA1_CTX* context)
+{
+u_int32_t i, j;
+u_int8_t finalcount[8];
+
+    for (i = 0; i < 8; i++) {
+        finalcount[i] = (u_int8_t)((context->count[(i >= 4 ? 0 : 1)]
+         >> ((3-(i & 3)) * 8) ) & 255);  /* Endian independent */
+    }
+    SHA1Update(context, (u_int8_t *)"\200", 1);
+    while ((context->count[0] & 504) != 448) {
+        SHA1Update(context, (u_int8_t *)"\0", 1);
+    }
+    SHA1Update(context, finalcount, 8);  /* Should cause a SHA1Transform() */
+    for (i = 0; i < 20; i++) {
+        digest[i] = (u_int8_t)
+         ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
+    }
+    /* Wipe variables */
+    i = j = 0;
+    memset(context->buffer, 0, 64);
+    memset(context->state, 0, 20);
+    memset(context->count, 0, 8);
+    memset(&finalcount, 0, 8);
+#ifdef SHA1HANDSOFF  /* make SHA1Transform overwrite it's own static vars */
+    SHA1Transform(context->state, context->buffer);
+#endif
+}

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/sha1.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/Crytpo/sha1.h
@@ -1,0 +1,14 @@
+
+// From http://www.mirrors.wiretapped.net/security/cryptography/hashes/sha1/sha1.c
+
+#include <sys/attr.h>
+
+typedef struct {
+    u_int32_t state[5];
+    u_int32_t count[2];
+    u_int8_t buffer[64];
+} SHA1_CTX;
+
+extern void SHA1Init(SHA1_CTX* context);
+extern void SHA1Update(SHA1_CTX* context, u_int8_t* data, u_int32_t len);
+extern void SHA1Final(u_int8_t digest[20], SHA1_CTX* context);

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OACall.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OACall.h
@@ -1,0 +1,63 @@
+//
+//  OACall.h
+//  OAuthConsumer
+//
+//  Created by Alberto García Hierro on 04/09/08.
+//  Copyright 2008 Alberto García Hierro. All rights reserved.
+//	bynotes.com
+
+#import <Foundation/Foundation.h>
+
+@class OAProblem;
+@class OACall;
+
+@protocol OACallDelegate
+
+- (void)call:(OACall *)call failedWithError:(NSError *)error;
+- (void)call:(OACall *)call failedWithProblem:(OAProblem *)problem;
+
+@end
+
+@class OAConsumer;
+@class OAToken;
+@class OADataFetcher;
+@class OAMutableURLRequest;
+@class OAServiceTicket;
+
+@interface OACall : NSObject {
+	NSURL *url;
+	NSString *method;
+	NSArray *parameters;
+	NSDictionary *files;
+	NSObject <OACallDelegate> *delegate;
+	SEL finishedSelector;
+	OADataFetcher *fetcher;
+	OAMutableURLRequest *request;
+	OAServiceTicket *ticket;
+}
+
+@property(readonly) NSURL *url;
+@property(readonly) NSString *method;
+@property(readonly) NSArray *parameters;
+@property(readonly) NSDictionary *files;
+@property(nonatomic, retain) OAServiceTicket *ticket;
+
+- (id)init;
+- (id)initWithURL:(NSURL *)aURL;
+- (id)initWithURL:(NSURL *)aURL method:(NSString *)aMethod;
+- (id)initWithURL:(NSURL *)aURL parameters:(NSArray *)theParameters;
+- (id)initWithURL:(NSURL *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters;
+- (id)initWithURL:(NSURL *)aURL parameters:(NSArray *)theParameters files:(NSDictionary*)theFiles;
+
+- (id)initWithURL:(NSURL *)aURL
+		   method:(NSString *)aMethod
+	   parameters:(NSArray *)theParameters
+			files:(NSDictionary*)theFiles;
+
+- (void)perform:(OAConsumer *)consumer
+		  token:(OAToken *)token
+		  realm:(NSString *)realm
+	   delegate:(NSObject <OACallDelegate> *)aDelegate
+	  didFinish:(SEL)finished;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OACall.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OACall.m
@@ -1,0 +1,151 @@
+//
+//  OACall.m
+//  OAuthConsumer
+//
+//  Created by Alberto García Hierro on 04/09/08.
+//  Copyright 2008 Alberto García Hierro. All rights reserved.
+//	bynotes.com
+
+#import "OAConsumer.h"
+#import "OAToken.h"
+#import "OAProblem.h"
+#import "OADataFetcher.h"
+#import "OAServiceTicket.h"
+#import "OAMutableURLRequest.h"
+#import "OACall.h"
+
+@interface OACall (Private)
+
+- (void)callFinished:(OAServiceTicket *)ticket withData:(NSData *)data;
+- (void)callFailed:(OAServiceTicket *)ticket withError:(NSError *)error;
+
+@end
+
+@implementation OACall
+
+@synthesize url, method, parameters, files, ticket;
+
+- (id)init {
+	return [self initWithURL:nil
+					  method:nil
+				  parameters:nil
+					   files:nil];
+}
+
+- (id)initWithURL:(NSURL *)aURL {
+	return [self initWithURL:aURL
+					  method:nil
+				  parameters:nil
+					   files:nil];
+}
+
+- (id)initWithURL:(NSURL *)aURL method:(NSString *)aMethod {
+	return [self initWithURL:aURL
+					  method:aMethod
+				  parameters:nil
+					   files:nil];
+}
+
+- (id)initWithURL:(NSURL *)aURL parameters:(NSArray *)theParameters {
+	return [self initWithURL:aURL
+					  method:nil
+				  parameters:theParameters];
+}
+
+- (id)initWithURL:(NSURL *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters {
+	return [self initWithURL:aURL
+					  method:aMethod
+				  parameters:theParameters
+					   files:nil];
+}
+
+- (id)initWithURL:(NSURL *)aURL parameters:(NSArray *)theParameters files:(NSDictionary*)theFiles {
+	return [self initWithURL:aURL
+					  method:@"POST"
+				  parameters:theParameters
+					   files:theFiles];
+}
+
+- (id)initWithURL:(NSURL *)aURL
+		   method:(NSString *)aMethod
+	   parameters:(NSArray *)theParameters
+			files:(NSDictionary*)theFiles {
+    url = aURL;
+    method = aMethod;
+    parameters = theParameters;
+	files = theFiles;
+	fetcher = nil;
+	request = nil;
+	
+	return self;
+}
+
+- (void)callFailed:(OAServiceTicket *)aTicket withError:(NSError *)error {
+	NSLog(@"error body: %@", aTicket.body);
+	self.ticket = aTicket;
+	OAProblem *problem = [OAProblem problemWithResponseBody:ticket.body];
+	if (problem) {
+		[delegate call:self failedWithProblem:problem];
+	} else {
+		[delegate call:self failedWithError:error];
+	}
+}
+
+- (void)callFinished:(OAServiceTicket *)aTicket withData:(NSData *)data {
+	self.ticket = aTicket;
+	if (ticket.didSucceed) {
+//		NSLog(@"Call body: %@", ticket.body);
+		[delegate performSelector:finishedSelector withObject:self withObject:ticket.body];
+	} else {
+//		NSLog(@"Failed call body: %@", ticket.body);
+		[self callFailed:ticket withError:nil];
+	}
+}
+
+- (void)perform:(OAConsumer *)consumer
+		  token:(OAToken *)token
+		  realm:(NSString *)realm
+	   delegate:(NSObject <OACallDelegate> *)aDelegate
+	didFinish:(SEL)finished
+
+{
+	delegate = aDelegate;
+	finishedSelector = finished;
+
+	request = [[OAMutableURLRequest alloc] initWithURL:url
+											  consumer:consumer
+												token:token
+												 realm:realm
+									 signatureProvider:nil];
+	if(method) {
+		[request setHTTPMethod:method];
+	}
+
+	if (self.parameters) {
+		[request setParameters:self.parameters];
+	}
+
+	fetcher = [[OADataFetcher alloc] init];
+	[fetcher fetchDataWithRequest:request
+						 delegate:self
+				didFinishSelector:@selector(callFinished:withData:)
+				  didFailSelector:@selector(callFailed:withError:)];
+}
+
+/*- (BOOL)isEqual:(id)object {
+	if ([object isKindOfClass:[self class]]) {
+		return [self isEqualToCall:(OACall *)object];
+	}
+	return NO;
+}
+
+- (BOOL)isEqualToCall:(OACall *)aCall {
+	return (delegate == aCall->delegate
+			&& finishedSelector == aCall->finishedSelector 
+			&& [url isEqualTo:aCall.url]
+			&& [method isEqualToString:aCall.method]
+			&& [parameters isEqualToArray:aCall.parameters]
+			&& [files isEqualToDictionary:aCall.files]);
+}*/
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAConsumer.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAConsumer.h
@@ -1,0 +1,42 @@
+//
+//  OAConsumer.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+
+
+@interface OAConsumer : NSObject {
+@protected
+	NSString *key;
+	NSString *secret;
+}
+@property(copy, readwrite) NSString *key;
+@property(copy, readwrite) NSString *secret;
+
+- (id)initWithKey:(const NSString *)aKey secret:(const NSString *)aSecret;
+
+- (BOOL)isEqualToConsumer:(OAConsumer *)aConsumer;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAConsumer.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAConsumer.m
@@ -31,7 +31,7 @@
 
 #pragma mark init
 
-- (id)initWithKey:(const NSString *)aKey secret:(const NSString *)aSecret {
+- (id)initWithKey:(NSString * const )aKey secret:(NSString * const )aSecret {
 	self = [super init];
     self.key = aKey;
     self.secret = aSecret;

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAConsumer.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAConsumer.m
@@ -1,0 +1,53 @@
+//
+//  OAConsumer.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import "OAConsumer.h"
+
+
+@implementation OAConsumer
+@synthesize key, secret;
+
+#pragma mark init
+
+- (id)initWithKey:(const NSString *)aKey secret:(const NSString *)aSecret {
+	self = [super init];
+    self.key = aKey;
+    self.secret = aSecret;
+	return self;
+}
+
+- (BOOL)isEqual:(id)object {
+	if ([object isKindOfClass:[self class]]) {
+		return [self isEqualToConsumer:(OAConsumer*)object];
+	}
+	return NO;
+}
+
+- (BOOL)isEqualToConsumer:(OAConsumer *)aConsumer {
+	return ([self.key isEqualToString:aConsumer.key] &&
+			[self.secret isEqualToString:aConsumer.secret]);
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OADataFetcher.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OADataFetcher.h
@@ -1,0 +1,44 @@
+//
+//  OADataFetcher.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 11/5/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "OAMutableURLRequest.h"
+#import "OAServiceTicket.h"
+
+
+@interface OADataFetcher : NSObject {
+@private
+    OAMutableURLRequest *request;
+    NSURLResponse *response;
+    NSURLConnection *connection;
+    NSMutableData *responseData;
+    id delegate;
+    SEL didFinishSelector;
+    SEL didFailSelector;
+}
+
+- (void)fetchDataWithRequest:(OAMutableURLRequest *)aRequest delegate:(id)aDelegate didFinishSelector:(SEL)finishSelector didFailSelector:(SEL)failSelector;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OADataFetcher.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OADataFetcher.m
@@ -1,0 +1,77 @@
+//
+//  OADataFetcher.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 11/5/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "OADataFetcher.h"
+
+
+@implementation OADataFetcher
+
+- (id)init {
+	self = [super init];
+	responseData = [[NSMutableData alloc] init];
+	return self;
+}
+
+/* Protocol for async URL loading */
+- (void)connection:(NSURLConnection *)aConnection didReceiveResponse:(NSURLResponse *)aResponse {
+    response = aResponse;
+	[responseData setLength:0];
+}
+	
+- (void)connection:(NSURLConnection *)aConnection didFailWithError:(NSError *)error {
+	OAServiceTicket *ticket = [[OAServiceTicket alloc] initWithRequest:request
+															  response:response
+																  data:responseData
+															didSucceed:NO];
+
+	[delegate performSelector:didFailSelector withObject:ticket withObject:error];
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
+	[responseData appendData:data];
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
+	OAServiceTicket *ticket = [[OAServiceTicket alloc] initWithRequest:request
+															  response:response
+																  data:responseData
+															didSucceed:[(NSHTTPURLResponse *)response statusCode] < 400];
+
+	[delegate performSelector:didFinishSelector withObject:ticket withObject:responseData];
+}
+
+- (void)fetchDataWithRequest:(OAMutableURLRequest *)aRequest delegate:(id)aDelegate didFinishSelector:(SEL)finishSelector didFailSelector:(SEL)failSelector {
+    request = aRequest;
+    delegate = aDelegate;
+    didFinishSelector = finishSelector;
+    didFailSelector = failSelector;
+    
+    [request prepare];
+
+	connection = [[NSURLConnection alloc] initWithRequest:aRequest delegate:self];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAHMAC_SHA1SignatureProvider.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAHMAC_SHA1SignatureProvider.h
@@ -1,0 +1,32 @@
+//
+//  OAHMAC_SHA1SignatureProvider.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+#import "OASignatureProviding.h"
+
+
+@interface OAHMAC_SHA1SignatureProvider : NSObject <OASignatureProviding>
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAHMAC_SHA1SignatureProvider.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAHMAC_SHA1SignatureProvider.m
@@ -1,0 +1,56 @@
+//
+//  OAHMAC_SHA1SignatureProvider.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "OAHMAC_SHA1SignatureProvider.h"
+
+#include "hmac.h"
+#include "Base64Transcoder.h"
+
+@implementation OAHMAC_SHA1SignatureProvider
+
+- (NSString *)name {
+    return @"HMAC-SHA1";
+}
+
+- (NSString *)signClearText:(NSString *)text withSecret:(NSString *)secret {
+    NSData *secretData = [secret dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *clearTextData = [text dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char result[20];
+    hmac_sha1((unsigned char *)[clearTextData bytes], [clearTextData length], (unsigned char *)[secretData bytes], [secretData length], result);
+    
+    //Base64 Encoding
+    
+    char base64Result[32];
+    size_t theResultLength = 32;
+    Base64EncodeData(result, 20, base64Result, &theResultLength);
+    NSData *theData = [NSData dataWithBytes:base64Result length:theResultLength];
+    
+    NSString *base64EncodedResult = [[NSString alloc] initWithData:theData encoding:NSUTF8StringEncoding];
+    
+    return base64EncodedResult;
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAMutableURLRequest.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAMutableURLRequest.h
@@ -1,0 +1,67 @@
+//
+//  OAMutableURLRequest.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+#import "OAConsumer.h"
+#import "OAToken.h"
+#import "OAHMAC_SHA1SignatureProvider.h"
+#import "OASignatureProviding.h"
+#import "NSMutableURLRequest+Parameters.h"
+#import "NSURL+Base.h"
+
+
+@interface OAMutableURLRequest : NSMutableURLRequest {
+@protected
+    OAConsumer *consumer;
+    OAToken *token;
+    NSString *realm;
+    NSString *signature;
+    id<OASignatureProviding> signatureProvider;
+    NSString *nonce;
+    NSString *timestamp;
+}
+@property(readonly) NSString *signature;
+@property(readonly) NSString *nonce;
+
+- (id)initWithURL:(NSURL *)aUrl
+		 consumer:(OAConsumer *)aConsumer
+			token:(OAToken *)aToken
+            realm:(NSString *)aRealm
+signatureProvider:(id<OASignatureProviding, NSObject>)aProvider;
+
+- (id)initWithURL:(NSURL *)aUrl
+		 consumer:(OAConsumer *)aConsumer
+			token:(OAToken *)aToken
+            realm:(NSString *)aRealm
+signatureProvider:(id<OASignatureProviding, NSObject>)aProvider
+            nonce:(NSString *)aNonce
+        timestamp:(NSString *)aTimestamp;
+
+- (void)prepare;
+
+- (NSString *)signatureBaseString;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAMutableURLRequest.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAMutableURLRequest.m
@@ -1,0 +1,183 @@
+//
+//  OAMutableURLRequest.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "OAMutableURLRequest.h"
+
+
+@interface OAMutableURLRequest (Private)
+- (void)_generateTimestamp;
+- (void)_generateNonce;
+@end
+
+@implementation OAMutableURLRequest
+@synthesize signature, nonce;
+
+#pragma mark init
+
+- (id)initWithURL:(NSURL *)aUrl
+		 consumer:(OAConsumer *)aConsumer
+			token:(OAToken *)aToken
+            realm:(NSString *)aRealm
+signatureProvider:(id<OASignatureProviding, NSObject>)aProvider {
+    
+    self = [super initWithURL:aUrl
+           cachePolicy:NSURLRequestReloadIgnoringCacheData
+       timeoutInterval:10.0];
+    
+    consumer = aConsumer;
+    
+    // empty token for Unauthorized Request Token transaction
+    if (aToken == nil) {
+        token = [[OAToken alloc] init];
+    } else {
+        token = aToken;
+    }
+    
+    if (aRealm == nil) {
+        realm = @"";
+    } else {
+        realm = [aRealm copy];
+    }
+      
+    // default to HMAC-SHA1
+    if (aProvider == nil) {
+        signatureProvider = [[OAHMAC_SHA1SignatureProvider alloc] init];
+    } else {
+        signatureProvider = aProvider;
+    }
+    
+    [self _generateTimestamp];
+    [self _generateNonce];
+    
+    return self;
+}
+
+// Setting a timestamp and nonce to known
+// values can be helpful for testing
+- (id)initWithURL:(NSURL *)aUrl
+		 consumer:(OAConsumer *)aConsumer
+			token:(OAToken *)aToken
+            realm:(NSString *)aRealm
+signatureProvider:(id<OASignatureProviding, NSObject>)aProvider
+            nonce:(NSString *)aNonce
+        timestamp:(NSString *)aTimestamp {
+    self = [self initWithURL:aUrl
+             consumer:aConsumer
+                token:aToken
+                realm:aRealm
+    signatureProvider:aProvider];
+    
+    nonce = [aNonce copy];
+    timestamp = [aTimestamp copy];
+    
+    return self;
+}
+
+- (void)prepare {
+    // sign
+//	NSLog(@"Base string is: %@", [self _signatureBaseString]);
+   signature = [signatureProvider signClearText:[self signatureBaseString]
+                                      withSecret:[NSString stringWithFormat:@"%@&%@",
+                                                  [consumer.secret encodedURLParameterString],
+                                                  token.secret ? [token.secret encodedURLParameterString] : @""]];
+    
+    // set OAuth headers
+	NSMutableArray *chunks = [[NSMutableArray alloc] init];
+	[chunks addObject:[NSString stringWithFormat:@"realm=\"%@\"", [realm encodedURLParameterString]]];
+	[chunks addObject:[NSString stringWithFormat:@"oauth_consumer_key=\"%@\"", [consumer.key encodedURLParameterString]]];
+
+	NSDictionary *tokenParameters = [token parameters];
+	for (NSString *k in tokenParameters) {
+		[chunks addObject:[NSString stringWithFormat:@"%@=\"%@\"", k, [[tokenParameters objectForKey:k] encodedURLParameterString]]];
+	}
+
+	[chunks addObject:[NSString stringWithFormat:@"oauth_signature_method=\"%@\"", [[signatureProvider name] encodedURLParameterString]]];
+	[chunks addObject:[NSString stringWithFormat:@"oauth_signature=\"%@\"", [signature encodedURLParameterString]]];
+	[chunks addObject:[NSString stringWithFormat:@"oauth_timestamp=\"%@\"", timestamp]];
+	[chunks addObject:[NSString stringWithFormat:@"oauth_nonce=\"%@\"", nonce]];
+	[chunks	addObject:@"oauth_version=\"1.0\""];
+	
+	NSString *oauthHeader = [NSString stringWithFormat:@"OAuth %@", [chunks componentsJoinedByString:@", "]];
+
+    [self setValue:oauthHeader forHTTPHeaderField:@"Authorization"];
+}
+
+- (void)_generateTimestamp {
+    timestamp = [[NSString alloc]initWithFormat:@"%ld", time(NULL)];
+}
+
+- (void)_generateNonce {
+    CFUUIDRef theUUID = CFUUIDCreate(NULL);
+    CFStringRef string = CFUUIDCreateString(NULL, theUUID);
+	if (nonce) {
+		CFRelease((__bridge CFTypeRef)(nonce));
+	}
+    nonce = (__bridge NSString *)string;
+}
+
+- (NSString *)signatureBaseString {
+    // OAuth Spec, Section 9.1.1 "Normalize Request Parameters"
+    // build a sorted array of both request parameters and OAuth header parameters
+	NSDictionary *tokenParameters = [token parameters];
+	// 6 being the number of OAuth params in the Signature Base String
+	NSArray *parameters = [self parameters];
+	NSMutableArray *parameterPairs = [[NSMutableArray alloc] initWithCapacity:(5 + [parameters count] + [tokenParameters count])];
+    
+	OARequestParameter *parameter;
+	parameter = [[OARequestParameter alloc] initWithName:@"oauth_consumer_key" value:consumer.key];
+	
+    [parameterPairs addObject:[parameter URLEncodedNameValuePair]];
+	parameter = [[OARequestParameter alloc] initWithName:@"oauth_signature_method" value:[signatureProvider name]];
+    [parameterPairs addObject:[parameter URLEncodedNameValuePair]];
+	parameter = [[OARequestParameter alloc] initWithName:@"oauth_timestamp" value:timestamp];
+    [parameterPairs addObject:[parameter URLEncodedNameValuePair]];
+	parameter = [[OARequestParameter alloc] initWithName:@"oauth_nonce" value:nonce];
+    [parameterPairs addObject:[parameter URLEncodedNameValuePair]];
+	parameter = [[OARequestParameter alloc] initWithName:@"oauth_version" value:@"1.0"] ;
+    [parameterPairs addObject:[parameter URLEncodedNameValuePair]];
+	
+	for(NSString *k in tokenParameters) {
+		[parameterPairs addObject:[[OARequestParameter requestParameter:k value:[tokenParameters objectForKey:k]] URLEncodedNameValuePair]];
+	}
+    
+	if (![[self valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"multipart/form-data"]) {
+		for (OARequestParameter *param in parameters) {
+			[parameterPairs addObject:[param URLEncodedNameValuePair]];
+		}
+	}
+    
+    NSArray *sortedPairs = [parameterPairs sortedArrayUsingSelector:@selector(compare:)];
+    NSString *normalizedRequestParameters = [sortedPairs componentsJoinedByString:@"&"];
+	//	NSLog(@"Normalized: %@", normalizedRequestParameters);
+    // OAuth Spec, Section 9.1.2 "Concatenate Request Elements"
+    return [NSString stringWithFormat:@"%@&%@&%@",
+            [self HTTPMethod],
+            [[[self URL] URLStringWithoutQuery] encodedURLParameterString],
+            [normalizedRequestParameters encodedURLString]];
+}
+
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAPlaintextSignatureProvider.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAPlaintextSignatureProvider.h
@@ -1,0 +1,31 @@
+//
+//  OAPlaintextSignatureProvider.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+#import "OASignatureProviding.h"
+
+@interface OAPlaintextSignatureProvider : NSObject <OASignatureProviding>
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAPlaintextSignatureProvider.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAPlaintextSignatureProvider.m
@@ -1,0 +1,40 @@
+//
+//  OAPlaintextSignatureProvider.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "OAPlaintextSignatureProvider.h"
+
+
+@implementation OAPlaintextSignatureProvider
+
+- (NSString *)name {
+    return @"PLAINTEXT";
+}
+
+- (NSString *)signClearText:(NSString *)text withSecret:(NSString *)secret {
+    return secret;
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAProblem.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAProblem.h
@@ -1,0 +1,53 @@
+//
+//  OAProblem.h
+//  OAuthConsumer
+//
+//  Created by Alberto García Hierro on 03/09/08.
+//  Copyright 2008 Alberto García Hierro. All rights reserved.
+//	bynotes.com
+
+#import <Foundation/Foundation.h>
+
+enum {
+	kOAProblemSignatureMethodRejected = 0,
+	kOAProblemParameterAbsent,
+	kOAProblemVersionRejected,
+	kOAProblemConsumerKeyUnknown,
+	kOAProblemTokenRejected,
+	kOAProblemSignatureInvalid,
+	kOAProblemNonceUsed,
+	kOAProblemTimestampRefused,
+	kOAProblemTokenExpired,
+	kOAProblemTokenNotRenewable
+};
+
+@interface OAProblem : NSObject {
+	const NSString *problem;
+}
+
+@property (readonly) const NSString *problem;
+
+- (id)initWithProblem:(const NSString *)aProblem;
+- (id)initWithResponseBody:(const NSString *)response;
+
+- (BOOL)isEqualToProblem:(OAProblem *)aProblem;
+- (BOOL)isEqualToString:(const NSString *)aProblem;
+- (BOOL)isEqualTo:(id)aProblem;
+- (int)code;
+
++ (OAProblem *)problemWithResponseBody:(const NSString *)response;
+
++ (const NSArray *)validProblems;
+
++ (OAProblem *)SignatureMethodRejected;
++ (OAProblem *)ParameterAbsent;
++ (OAProblem *)VersionRejected;
++ (OAProblem *)ConsumerKeyUnknown;
++ (OAProblem *)TokenRejected;
++ (OAProblem *)SignatureInvalid;
++ (OAProblem *)NonceUsed;
++ (OAProblem *)TimestampRefused;
++ (OAProblem *)TokenExpired;
++ (OAProblem *)TokenNotRenewable;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAProblem.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAProblem.m
@@ -1,0 +1,165 @@
+//
+//  OAProblem.m
+//  OAuthConsumer
+//
+//  Created by Alberto García Hierro on 03/09/08.
+//  Copyright 2008 Alberto García Hierro. All rights reserved.
+//	bynotes.com
+
+#import "OAProblem.h"
+
+const NSString *signature_method_rejected = @"signature_method_rejected";
+const NSString *parameter_absent = @"parameter_absent";
+const NSString *version_rejected = @"version_rejected";
+const NSString *consumer_key_unknown = @"consumer_key_unknown";
+const NSString *token_rejected = @"token_rejected";
+const NSString *signature_invalid = @"signature_invalid";
+const NSString *nonce_used = @"nonce_used";
+const NSString *timestamp_refused = @"timestamp_refused";
+const NSString *token_expired = @"token_expired";
+const NSString *token_not_renewable = @"token_not_renewable";
+
+@implementation OAProblem
+
+@synthesize problem;
+
+- (id)initWithPointer:(const NSString *) aPointer
+{
+	self = [super init];
+	problem = aPointer;
+	return self;
+}
+
+- (id)initWithProblem:(const NSString *) aProblem
+{
+	NSUInteger idx = [[OAProblem validProblems] indexOfObject:aProblem];
+	if (idx == NSNotFound) {
+		return nil;
+	}
+	
+	return [self initWithPointer: [[OAProblem validProblems] objectAtIndex:idx]];
+}
+	
+- (id)initWithResponseBody:(const NSString *) response
+{
+	NSArray *fields = [response componentsSeparatedByString:@"&"];
+	for (NSString *field in fields) {
+		if ([field hasPrefix:@"oauth_problem="]) {
+			NSString *value = [[field componentsSeparatedByString:@"="] objectAtIndex:1];
+			return [self initWithProblem:value];
+		}
+	}
+	
+	return nil;
+}
+
++ (OAProblem *)problemWithResponseBody:(const NSString *) response
+{
+    return [[OAProblem alloc] initWithResponseBody:response];
+}
+
++ (const NSArray *)validProblems
+{
+	static NSArray *array;
+	if (!array) {
+		array = [[NSArray alloc] initWithObjects:signature_method_rejected,
+										parameter_absent,
+										version_rejected,
+										consumer_key_unknown,
+										token_rejected,
+										signature_invalid,
+										nonce_used,
+										timestamp_refused,
+										token_expired,
+										token_not_renewable,
+										nil];
+	}
+	
+	return array;
+}
+
+- (BOOL)isEqualToProblem:(OAProblem *) aProblem
+{
+	return [problem isEqualToString:(NSString *)aProblem->problem];
+}
+
+- (BOOL)isEqualToString:(const NSString *) aProblem
+{
+	return [problem isEqualToString:(NSString *)aProblem];
+}
+
+- (BOOL)isEqualTo:(id) aProblem
+{
+	if ([aProblem isKindOfClass:[NSString class]]) {
+		return [self isEqualToString:aProblem];
+	}
+		
+	if ([aProblem isKindOfClass:[OAProblem class]]) {
+		return [self isEqualToProblem:aProblem];
+	}
+	
+	return NO;
+}
+
+- (int)code {
+	return [[[self class] validProblems] indexOfObject:problem];
+}
+
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"OAuth Problem: %@", (NSString *)problem];
+}
+
+#pragma mark class_methods
+
++ (OAProblem *)SignatureMethodRejected
+{
+    return [[OAProblem alloc] initWithPointer:signature_method_rejected];
+}
+
++ (OAProblem *)ParameterAbsent
+{
+    return [[OAProblem alloc] initWithPointer:parameter_absent];
+}
+
++ (OAProblem *)VersionRejected
+{
+	return [[OAProblem alloc] initWithPointer:version_rejected];
+}
+
++ (OAProblem *)ConsumerKeyUnknown
+{
+	return [[OAProblem alloc] initWithPointer:consumer_key_unknown];
+}
+
++ (OAProblem *)TokenRejected
+{
+    return [[OAProblem alloc] initWithPointer:token_rejected];
+}
+
++ (OAProblem *)SignatureInvalid
+{
+    return [[OAProblem alloc] initWithPointer:signature_invalid];
+}
+
++ (OAProblem *)NonceUsed
+{
+    return [[OAProblem alloc] initWithPointer:nonce_used];
+}
+
++ (OAProblem *)TimestampRefused
+{
+    return [[OAProblem alloc] initWithPointer:timestamp_refused];
+}
+
++ (OAProblem *)TokenExpired
+{
+    return [[OAProblem alloc] initWithPointer:token_expired];
+}
+
++ (OAProblem *)TokenNotRenewable
+{
+    return [[OAProblem alloc] initWithPointer:token_not_renewable];
+}
+					  
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OARequestParameter.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OARequestParameter.h
@@ -1,0 +1,48 @@
+//
+//  OARequestParameter.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+#import "NSString+URLEncoding.h"
+
+
+@interface OARequestParameter : NSObject {
+@protected
+    NSString *name;
+    NSString *value;
+}
+@property(copy, readwrite) NSString *name;
+@property(copy, readwrite) NSString *value;
+
+- (id)initWithName:(NSString *)aName value:(NSString *)aValue;
+- (NSString *)URLEncodedName;
+- (NSString *)URLEncodedValue;
+- (NSString *)URLEncodedNameValuePair;
+
+- (BOOL)isEqualToRequestParameter:(OARequestParameter *)parameter;
+
++ (id)requestParameter:(NSString *)aName value:(NSString *)aValue;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OARequestParameter.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OARequestParameter.m
@@ -1,0 +1,72 @@
+//
+//  OARequestParameter.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "OARequestParameter.h"
+
+
+@implementation OARequestParameter
+@synthesize name, value;
+
+- (id)initWithName:(NSString *)aName value:(NSString *)aValue {
+    self = [super init];
+    self.name = aName;
+    self.value = aValue;
+    return self;
+}
+
+- (NSString *)URLEncodedName {
+	return self.name;
+//    return [self.name encodedURLParameterString];
+}
+
+- (NSString *)URLEncodedValue {
+    return [self.value encodedURLParameterString];
+}
+
+- (NSString *)URLEncodedNameValuePair {
+    return [NSString stringWithFormat:@"%@=%@", [self URLEncodedName], [self URLEncodedValue]];
+}
+
+- (BOOL)isEqual:(id)object {
+	if ([object isKindOfClass:[self class]]) {
+		return [self isEqualToRequestParameter:(OARequestParameter *)object];
+	}
+	
+	return NO;
+}
+
+- (BOOL)isEqualToRequestParameter:(OARequestParameter *)parameter {
+	return ([self.name isEqualToString:parameter.name] &&
+			[self.value isEqualToString:parameter.value]);
+}
+
+
++ (id)requestParameter:(NSString *)aName value:(NSString *)aValue
+{
+    return [[self alloc] initWithName:aName value:aValue];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAServiceTicket.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAServiceTicket.h
@@ -1,0 +1,46 @@
+//
+//  OAServiceTicket.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 11/5/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+#import "OAMutableURLRequest.h"
+
+
+@interface OAServiceTicket : NSObject {
+@private
+    OAMutableURLRequest *request;
+    NSURLResponse *response;
+	NSData *data;
+    BOOL didSucceed;
+}
+@property(readonly) OAMutableURLRequest *request;
+@property(readonly) NSURLResponse *response;
+@property(readonly) NSData *data;
+@property(readonly) BOOL didSucceed;
+@property(readonly) NSString *body;
+
+- (id)initWithRequest:(OAMutableURLRequest *)aRequest response:(NSURLResponse *)aResponse data:(NSData *)aData didSucceed:(BOOL)success;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAServiceTicket.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAServiceTicket.m
@@ -1,0 +1,51 @@
+//
+//  OAServiceTicket.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 11/5/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "OAServiceTicket.h"
+
+
+@implementation OAServiceTicket
+@synthesize request, response, data, didSucceed;
+
+- (id)initWithRequest:(OAMutableURLRequest *)aRequest response:(NSURLResponse *)aResponse data:(NSData *)aData didSucceed:(BOOL)success {
+    self = [super init];
+    request = aRequest;
+    response = aResponse;
+	data = aData;
+    didSucceed = success;
+    return self;
+}
+
+- (NSString *)body
+{
+	if (!data) {
+		return nil;
+	}
+	
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OASignatureProviding.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OASignatureProviding.h
@@ -1,0 +1,34 @@
+//
+//  OASignatureProviding.h
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+
+
+@protocol OASignatureProviding
+
+- (NSString *)name;
+- (NSString *)signClearText:(NSString *)text withSecret:(NSString *)secret;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.h
@@ -1,0 +1,72 @@
+//
+//  OAToken.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@interface OAToken : NSObject {
+@protected
+	NSString *key;
+	NSString *secret;
+	NSString *session;
+	NSNumber *duration;
+	NSMutableDictionary *attributes;
+	NSDate *created;
+	BOOL renewable;
+	BOOL forRenewal;
+}
+@property(retain, readwrite) NSString *key;
+@property(retain, readwrite) NSString *secret;
+@property(retain, readwrite) NSString *session;
+@property(retain, readwrite) NSNumber *duration;
+@property(retain, readwrite) NSMutableDictionary *attributes;
+@property(readwrite, getter=isForRenewal) BOOL forRenewal;
+
+- (id)initWithKey:(NSString *)aKey secret:(NSString *)aSecret;
+- (id)initWithKey:(NSString *)aKey secret:(NSString *)aSecret session:(NSString *)aSession
+		 duration:(NSNumber *)aDuration attributes:(NSDictionary *)theAttributes created:(NSDate *)creation
+		renewable:(BOOL)renew;
+- (id)initWithHTTPResponseBody:(NSString *)body;
+
+- (id)initWithUserDefaultsUsingServiceProviderName:(NSString *)provider prefix:(NSString *)prefix;
+- (int)storeInUserDefaultsWithServiceProviderName:(NSString *)provider prefix:(NSString *)prefix;
+
+- (BOOL)isValid;
+
+- (void)setAttribute:(NSString *)aKey value:(NSString *)aValue;
+- (NSString *)attribute:(NSString *)aKey;
+- (void)setAttributesWithString:(NSString *)aAttributes;
+- (NSString *)attributeString;
+
+- (BOOL)hasExpired;
+- (BOOL)isRenewable;
+- (void)setDurationWithString:(NSString *)aDuration;
+- (BOOL)hasAttributes;
+- (NSDictionary *)parameters;
+
+- (BOOL)isEqualToToken:(OAToken *)aToken;
+
++ (void)removeFromUserDefaultsWithServiceProviderName:(const NSString *)provider prefix:(const NSString *)prefix;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.h
@@ -40,7 +40,7 @@
 @property(retain, readwrite) NSString *secret;
 @property(retain, readwrite) NSString *session;
 @property(retain, readwrite) NSNumber *duration;
-@property(retain, readwrite) NSMutableDictionary *attributes;
+@property(strong, readwrite, nonatomic) NSMutableDictionary *attributes;
 @property(readwrite, getter=isForRenewal) BOOL forRenewal;
 
 - (id)initWithKey:(NSString *)aKey secret:(NSString *)aSecret;
@@ -67,6 +67,6 @@
 
 - (BOOL)isEqualToToken:(OAToken *)aToken;
 
-+ (void)removeFromUserDefaultsWithServiceProviderName:(const NSString *)provider prefix:(const NSString *)prefix;
++ (void)removeFromUserDefaultsWithServiceProviderName:(NSString * const)provider prefix:(NSString * const )prefix;
 
 @end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.m
@@ -33,7 +33,7 @@
 + (id)loadSetting:(const NSString *)name provider:(const NSString *)provider prefix:(const NSString *)prefix;
 + (void)saveSetting:(NSString *)name object:(id)object provider:(const NSString *)provider prefix:(const NSString *)prefix;
 + (NSNumber *)durationWithString:(NSString *)aDuration;
-+ (NSDictionary *)attributesWithString:(NSString *)theAttributes;
++ (NSMutableDictionary *)attributesWithString:(NSString *)theAttributes;
 
 @end
 
@@ -53,7 +53,7 @@
 }
 
 - (id)initWithKey:(NSString *)aKey secret:(NSString *)aSecret session:(NSString *)aSession
-		 duration:(NSNumber *)aDuration attributes:(NSDictionary *)theAttributes created:(NSDate *)creation
+		 duration:(NSNumber *)aDuration attributes:(NSMutableDictionary *)theAttributes created:(NSDate *)creation
 		renewable:(BOOL)renew {
 	self = [super init];
 	self.key = aKey;
@@ -165,7 +165,7 @@
 	[attributes setObject: aAttribute forKey: aKey];
 }
 
-- (void)setAttributes:(NSDictionary *)theAttributes {
+- (void)setAttributes:(NSMutableDictionary *)theAttributes {
 	if (theAttributes) {
 		attributes = [[NSMutableDictionary alloc] initWithDictionary:theAttributes];
 	}else {
@@ -296,7 +296,7 @@
 	return [NSNumber numberWithInt: mult * [[aDuration substringToIndex:length - 1] intValue]];
 }
 
-+ (NSDictionary *)attributesWithString:(NSString *)theAttributes {
++ (NSMutableDictionary *)attributesWithString:(NSString *)theAttributes {
 	NSArray *attrs = [theAttributes componentsSeparatedByString:@";"];
 	NSMutableDictionary *dct = [[NSMutableDictionary alloc] init];
 	for (NSString *pair in attrs) {

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAToken.m
@@ -1,0 +1,315 @@
+//
+//  OAToken.m
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "NSString+URLEncoding.h"
+#import "OAToken.h"
+
+@interface OAToken (Private)
+
++ (NSString *)settingsKey:(const NSString *)name provider:(const NSString *)provider prefix:(const NSString *)prefix;
++ (id)loadSetting:(const NSString *)name provider:(const NSString *)provider prefix:(const NSString *)prefix;
++ (void)saveSetting:(NSString *)name object:(id)object provider:(const NSString *)provider prefix:(const NSString *)prefix;
++ (NSNumber *)durationWithString:(NSString *)aDuration;
++ (NSDictionary *)attributesWithString:(NSString *)theAttributes;
+
+@end
+
+@implementation OAToken
+
+@synthesize key, secret, session, duration, attributes, forRenewal;
+
+#pragma mark init
+
+- (id)init {
+	return [self initWithKey:nil secret:nil];
+}
+
+- (id)initWithKey:(NSString *)aKey secret:(NSString *)aSecret {
+	return [self initWithKey:aKey secret:aSecret session:nil duration:nil
+				  attributes:nil created:nil renewable:NO];
+}
+
+- (id)initWithKey:(NSString *)aKey secret:(NSString *)aSecret session:(NSString *)aSession
+		 duration:(NSNumber *)aDuration attributes:(NSDictionary *)theAttributes created:(NSDate *)creation
+		renewable:(BOOL)renew {
+	self = [super init];
+	self.key = aKey;
+	self.secret = aSecret;
+	self.session = aSession;
+	self.duration = aDuration;
+	self.attributes = theAttributes;
+	created = creation;
+	renewable = renew;
+	forRenewal = NO;
+
+	return self;
+}
+
+- (id)initWithHTTPResponseBody:(const NSString *)body {
+    NSString *aKey = nil;
+	NSString *aSecret = nil;
+	NSString *aSession = nil;
+	NSNumber *aDuration = nil;
+	NSDate *creationDate = nil;
+	NSDictionary *attrs = nil;
+	BOOL renew = NO;
+	NSArray *pairs = [body componentsSeparatedByString:@"&"];
+
+	for (NSString *pair in pairs) {
+        NSArray *elements = [pair componentsSeparatedByString:@"="];
+        if ([[elements objectAtIndex:0] isEqualToString:@"oauth_token"]) {
+            aKey = [elements objectAtIndex:1];
+        } else if ([[elements objectAtIndex:0] isEqualToString:@"oauth_token_secret"]) {
+            aSecret = [elements objectAtIndex:1];
+        } else if ([[elements objectAtIndex:0] isEqualToString:@"oauth_session_handle"]) {
+			aSession = [elements objectAtIndex:1];
+		} else if ([[elements objectAtIndex:0] isEqualToString:@"oauth_token_duration"]) {
+			aDuration = [[self class] durationWithString:[elements objectAtIndex:1]];
+			creationDate = [NSDate date];
+		} else if ([[elements objectAtIndex:0] isEqualToString:@"oauth_token_attributes"]) {
+			attrs = [[self class] attributesWithString:[[elements objectAtIndex:1] decodedURLString]];
+		} else if ([[elements objectAtIndex:0] isEqualToString:@"oauth_token_renewable"]) {
+			NSString *lowerCase = [[elements objectAtIndex:1] lowercaseString];
+			if ([lowerCase isEqualToString:@"true"] || [lowerCase isEqualToString:@"t"]) {
+				renew = YES;
+			}
+		}
+    }
+    
+    return [self initWithKey:aKey secret:aSecret session:aSession duration:aDuration
+				  attributes:attrs created:creationDate renewable:renew];
+}
+
+- (id)initWithUserDefaultsUsingServiceProviderName:(const NSString *)provider prefix:(const NSString *)prefix {
+	self = [super init];
+	self.key = [OAToken loadSetting:@"key" provider:provider prefix:prefix];
+	self.secret = [OAToken loadSetting:@"secret" provider:provider prefix:prefix];
+	self.session = [OAToken loadSetting:@"session" provider:provider prefix:prefix];
+	self.duration = [OAToken loadSetting:@"duration" provider:provider prefix:prefix];
+	self.attributes = [OAToken loadSetting:@"attributes" provider:provider prefix:prefix];
+	created = [OAToken loadSetting:@"created" provider:provider prefix:prefix];
+	renewable = [[OAToken loadSetting:@"renewable" provider:provider prefix:prefix] boolValue];
+
+	if (![self isValid]) {
+		return nil;
+	}
+	
+	return self;
+}
+
+#pragma mark settings
+
+- (BOOL)isValid {
+	return (key != nil && ![key isEqualToString:@""] && secret != nil && ![secret isEqualToString:@""]);
+}
+
+- (int)storeInUserDefaultsWithServiceProviderName:(const NSString *)provider prefix:(const NSString *)prefix {
+	[OAToken saveSetting:@"key" object:key provider:provider prefix:prefix];
+	[OAToken saveSetting:@"secret" object:secret provider:provider prefix:prefix];
+	[OAToken saveSetting:@"created" object:created provider:provider prefix:prefix];
+	[OAToken saveSetting:@"duration" object:duration provider:provider prefix:prefix];
+	[OAToken saveSetting:@"session" object:session provider:provider prefix:prefix];
+	[OAToken saveSetting:@"attributes" object:attributes provider:provider prefix:prefix];
+	[OAToken saveSetting:@"renewable" object:renewable ? @"t" : @"f" provider:provider prefix:prefix];
+	
+	[[NSUserDefaults standardUserDefaults] synchronize];
+	return(0);
+}
+
+#pragma mark duration
+
+- (void)setDurationWithString:(NSString *)aDuration {
+	self.duration = [[self class] durationWithString:aDuration];
+}
+
+- (BOOL)hasExpired
+{
+	return created && [created timeIntervalSinceNow] > [duration intValue];
+}
+
+- (BOOL)isRenewable
+{
+	return session && renewable && created && [created timeIntervalSinceNow] < (2 * [duration intValue]);
+}
+
+
+#pragma mark attributes
+
+- (void)setAttribute:(const NSString *)aKey value:(const NSString *)aAttribute {
+	if (!attributes) {
+		attributes = [[NSMutableDictionary alloc] init];
+	}
+	[attributes setObject: aAttribute forKey: aKey];
+}
+
+- (void)setAttributes:(NSDictionary *)theAttributes {
+	if (theAttributes) {
+		attributes = [[NSMutableDictionary alloc] initWithDictionary:theAttributes];
+	}else {
+		attributes = nil;
+	}
+	
+}
+
+- (BOOL)hasAttributes {
+	return (attributes && [attributes count] > 0);
+}
+
+- (NSString *)attributeString {
+	if (![self hasAttributes]) {
+		return @"";
+	}
+	
+	NSMutableArray *chunks = [[NSMutableArray alloc] init];
+	for(NSString *aKey in self->attributes) {
+		[chunks addObject:[NSString stringWithFormat:@"%@:%@", aKey, [attributes objectForKey:aKey]]];
+	}
+	NSString *attrs = [chunks componentsJoinedByString:@";"];
+	return attrs;
+}
+
+- (NSString *)attribute:(NSString *)aKey
+{
+	return [attributes objectForKey:aKey];
+}
+
+- (void)setAttributesWithString:(NSString *)theAttributes
+{
+	self.attributes = [[self class] attributesWithString:theAttributes];
+}
+
+- (NSDictionary *)parameters
+{
+	NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
+
+	if (key) {
+		[params setObject:key forKey:@"oauth_token"];
+		if ([self isForRenewal]) {
+			[params setObject:session forKey:@"oauth_session_handle"];
+		}
+	} else {
+		if (duration) {
+			[params setObject:[duration stringValue] forKey: @"oauth_token_duration"];
+		}
+		if ([attributes count]) {
+			[params setObject:[self attributeString] forKey:@"oauth_token_attributes"];
+		}
+	}
+	return params;
+}
+
+#pragma mark comparisions
+
+- (BOOL)isEqual:(id)object {
+	if([object isKindOfClass:[self class]]) {
+		return [self isEqualToToken:(OAToken *)object];
+	}
+	return NO;
+}
+
+- (BOOL)isEqualToToken:(OAToken *)aToken {
+	/* Since ScalableOAuth determines that the token may be
+	 renewed using the same key and secret, we must also
+	 check the creation date */
+	if ([self.key isEqualToString:aToken.key] &&
+		[self.secret isEqualToString:aToken.secret]) {
+		/* May be nil */
+		if (created == aToken->created || [created isEqualToDate:aToken->created]) {
+			return YES;
+		}
+	}
+	
+	return NO;
+}
+			
+#pragma mark class_functions
+			
++ (NSString *)settingsKey:(NSString *)name provider:(NSString *)provider prefix:(NSString *)prefix {
+	return [NSString stringWithFormat:@"OAUTH_%@_%@_%@", provider, prefix, [name uppercaseString]];
+}
+			
++ (id)loadSetting:(NSString *)name provider:(NSString *)provider prefix:(NSString *)prefix {
+	return [[NSUserDefaults standardUserDefaults] objectForKey:[self settingsKey:name
+																		provider:provider
+																		  prefix:prefix]];
+}
+			
++ (void)saveSetting:(NSString *)name object:(id)object provider:(NSString *)provider prefix:(NSString *)prefix {
+	[[NSUserDefaults standardUserDefaults] setObject:object forKey:[self settingsKey:name
+																			provider:provider
+																			  prefix:prefix]];
+}
+	
++ (void)removeFromUserDefaultsWithServiceProviderName:(NSString *)provider prefix:(NSString *)prefix {
+	NSArray *keys = [NSArray arrayWithObjects:@"key", @"secret", @"created", @"duration", @"session", @"attributes", @"renewable", nil];
+	for(NSString *name in keys) {
+		[[NSUserDefaults standardUserDefaults] removeObjectForKey:[OAToken settingsKey:name provider:provider prefix:prefix]];
+	}
+}
+			
++ (NSNumber *)durationWithString:(NSString *)aDuration {
+	NSUInteger length = [aDuration length];
+	unichar c = toupper([aDuration characterAtIndex:length - 1]);
+	int mult;
+	if (c >= '0' && c <= '9') {
+		return [NSNumber numberWithInt:[aDuration intValue]];
+	}
+	if (c == 'S') {
+		mult = 1;
+	} else if (c == 'H') {
+		mult = 60 * 60;
+	} else if (c == 'D') {
+		mult = 60 * 60 * 24;
+	} else if (c == 'W') {
+		mult = 60 * 60 * 24 * 7;
+	} else if (c == 'M') {
+		mult = 60 * 60 * 24 * 30;
+	} else if (c == 'Y') {
+		mult = 60 * 60 * 365;
+	} else {
+		mult = 1;
+	}
+	
+	return [NSNumber numberWithInt: mult * [[aDuration substringToIndex:length - 1] intValue]];
+}
+
++ (NSDictionary *)attributesWithString:(NSString *)theAttributes {
+	NSArray *attrs = [theAttributes componentsSeparatedByString:@";"];
+	NSMutableDictionary *dct = [[NSMutableDictionary alloc] init];
+	for (NSString *pair in attrs) {
+		NSArray *elements = [pair componentsSeparatedByString:@":"];
+		[dct setObject:[elements objectAtIndex:1] forKey:[elements objectAtIndex:0]];
+	}
+    return dct;
+}
+
+#pragma mark description
+
+- (NSString *)description {
+	return [NSString stringWithFormat:@"Key \"%@\" Secret:\"%@\"", key, secret];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OATokenManager.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OATokenManager.h
@@ -1,0 +1,68 @@
+//
+//  OATokenManager.h
+//  OAuthConsumer
+//
+//  Created by Alberto García Hierro on 01/09/08.
+//  Copyright 2008 Alberto García Hierro. All rights reserved.
+//	bynotes.com
+
+#import <Foundation/Foundation.h>
+
+#import "OACall.h"
+
+@class OATokenManager;
+
+@protocol OATokenManagerDelegate
+
+- (BOOL)tokenManager:(OATokenManager *)manager failedCall:(OACall *)call withError:(NSError *)error;
+- (BOOL)tokenManager:(OATokenManager *)manager failedCall:(OACall *)call withProblem:(OAProblem *)problem;
+
+@optional
+
+- (BOOL)tokenManagerNeedsToken:(OATokenManager *)manager;
+
+@end
+
+@class OAConsumer;
+@class OAToken;
+
+@interface OATokenManager : NSObject<OACallDelegate> {
+	OAConsumer *consumer;
+	OAToken *acToken;
+	OAToken *reqToken;
+	OAToken *initialToken;
+	NSString *authorizedTokenKey;
+	NSString *oauthBase;
+	NSString *realm;
+	NSString *callback;
+	NSObject <OATokenManagerDelegate> *delegate;
+	NSMutableArray *calls;
+	NSMutableArray *selectors;
+	NSMutableDictionary *delegates;
+	BOOL isDispatching;
+}
+
+
+- (id)init;
+
+- (id)initWithConsumer:(OAConsumer *)aConsumer token:(OAToken *)aToken oauthBase:(const NSString *)base
+				 realm:(const NSString *)aRealm callback:(const NSString *)aCallback
+			  delegate:(NSObject <OATokenManagerDelegate> *)aDelegate;
+
+- (void)authorizedToken:(const NSString *)key;
+
+- (void)fetchData:(NSString *)aURL finished:(SEL)didFinish;
+
+- (void)fetchData:(NSString *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters
+		 finished:(SEL)didFinish;
+
+- (void)fetchData:(NSString *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters
+			files:(NSDictionary *)theFiles finished:(SEL)didFinish;
+
+- (void)fetchData:(NSString *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters
+			files:(NSDictionary *)theFiles finished:(SEL)didFinish delegate:(NSObject*)aDelegate;
+
+- (void)call:(OACall *)call failedWithError:(NSError *)error;
+- (void)call:(OACall *)call failedWithProblem:(OAProblem *)problem;
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OATokenManager.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OATokenManager.m
@@ -1,0 +1,378 @@
+//
+//  OATokenManager.m
+//  OAuthConsumer
+//
+//  Created by Alberto García Hierro on 01/09/08.
+//  Copyright 2008 Alberto García Hierro. All rights reserved.
+//	bynotes.com
+
+#import "OAConsumer.h"
+#import "OAToken.h"
+#import "OAProblem.h"
+#import "OACall.h"
+#import "OATokenManager.h"
+
+@interface OATokenManager (Private)
+
+- (void)callProblem:(OACall *)call problem:(OAProblem *)problem;
+- (void)callError:(OACall *)call error:(NSError *)error;
+- (void)callFinished:(OACall *)call body:(NSString *)body;
+
+- (void)dispatch;
+- (void)performCall:(OACall *)aCall;
+
+- (void)requestToken;
+- (void)requestTokenReceived;
+- (void)exchangeToken;
+- (void)renewToken;
+- (void)accessTokenReceived;
+- (void)setAccessToken:(OAToken *)token;
+- (void)deleteSavedRequestToken;
+
+- (OACall *)queue;
+- (void)enqueue:(OACall *)call selector:(SEL)selector;
+- (void)dequeue:(OACall *)call;
+- (SEL)getSelector:(OACall *)call;
+
+@end
+
+@implementation OATokenManager
+
+- (id)init {
+	return [self initWithConsumer:nil
+							token:nil
+						oauthBase:nil
+							realm:nil
+						 callback:nil
+						 delegate:nil];
+}
+
+- (id)initWithConsumer:(OAConsumer *)aConsumer token:(OAToken *)aToken oauthBase:(const NSString *)base
+				 realm:(const NSString *)aRealm callback:(const NSString *)aCallback
+			  delegate:(NSObject <OATokenManagerDelegate> *)aDelegate {
+
+	self = [super init];
+	consumer = aConsumer;
+	acToken = nil;
+	reqToken = nil;
+	initialToken = aToken;
+	authorizedTokenKey = nil;
+	oauthBase = [base copy];
+	realm = [aRealm copy];
+	callback = [aCallback copy];
+	delegate = aDelegate;
+	calls = [[NSMutableArray alloc] init];
+	selectors = [[NSMutableArray alloc] init];
+	delegates = [[NSMutableDictionary alloc] init];
+	isDispatching = NO;
+
+	return self;
+}
+
+// The application got a new authorized
+// request token and is notifying us
+- (void)authorizedToken:(const NSString *)aKey
+{
+	if (reqToken && [aKey isEqualToString:reqToken.key]) {
+		[self exchangeToken];
+	} else {
+		authorizedTokenKey = aKey;
+	}
+}
+
+
+// Private functions
+
+// Deal with problems and errors in calls
+
+- (void)call:(OACall *)call failedWithProblem:(OAProblem *)problem
+{
+	/* Always clear the saved request token, just in case */
+	[self deleteSavedRequestToken];
+	
+	if ([problem isEqualToProblem:[OAProblem TokenExpired]]) {
+		/* renewToken checks if it's renewable */
+		[self renewToken];
+	} else if ([problem isEqualToProblem:[OAProblem TokenNotRenewable]] || 
+			   [problem isEqualToProblem:[OAProblem TokenRejected]]) {
+		/* This token may have been revoked by the user, get a new one
+		 after removing the stored requestToken, since the problem may be in
+		 it */
+		[self setAccessToken:nil];
+		[self requestToken];
+	} else if ([problem isEqualToProblem:[OAProblem NonceUsed]]) {
+		/* Just repeat this request */
+		[self performCall:call];
+	} else {
+		/* Non-recoverable error, tell the delegate and dequeue the call
+		 if appropiate */
+		if([delegate tokenManager:self failedCall:call withProblem:problem]) {
+			[self dequeue:call];
+		}
+		@synchronized(self) {
+			isDispatching = NO;
+		}
+	}
+}
+
+- (void)call:(OACall *)call failedWithError:(NSError *)error
+{
+	if([delegate tokenManager:self failedCall:call withError:error]) {
+		[self dequeue:call];
+	}
+	@synchronized(self) {
+		isDispatching = NO;
+	}
+}
+
+// When a call finish, notify the delegate
+- (void)callFinished:(OACall *)call body:(NSString *)body
+{
+	SEL selector = [self getSelector:call];
+	id deleg = [delegates objectForKey:[NSString stringWithFormat:@"%p", call]];
+	if (deleg) {
+		[deleg performSelector:selector withObject:body];
+		[delegates removeObjectForKey:call];
+	} else {
+		[delegate performSelector:selector withObject:body];
+	}
+	@synchronized(self) {
+		isDispatching = NO;
+	}
+	[self dequeue:call];
+	[self dispatch];
+}
+
+- (OACall *)queue {
+	id obj = nil;
+	@synchronized(calls) {
+		if ([calls count]) {
+			obj = [calls objectAtIndex:0];
+		}
+	}
+	return obj;
+}
+
+- (void)enqueue:(OACall *)call selector:(SEL)selector {
+	NSUInteger idx = [calls indexOfObject:call];
+	if (idx == NSNotFound) {
+		@synchronized(calls) {
+			[calls addObject:call];
+			[selectors addObject:NSStringFromSelector(selector)];
+		}
+	}
+}
+
+- (void)dequeue:(OACall *)call {
+	NSUInteger idx = [calls indexOfObject:call];
+	if (idx != NSNotFound) {
+		@synchronized(calls) {
+			[calls removeObjectAtIndex:idx];
+			[selectors removeObjectAtIndex:idx];
+		}
+	}
+}
+
+- (SEL)getSelector:(OACall *)call
+{
+	NSUInteger idx = [calls indexOfObject:call];
+	if (idx != NSNotFound) {
+		return NSSelectorFromString([selectors objectAtIndex:idx]);
+	}
+	return 0;
+}
+	
+// Token management functions
+
+// Requesting a new token
+
+// Gets a new token and opens the default
+// browser for authorizing it. The application
+// is expected to call authorizedToken when it
+// gets the authorized token back
+
+- (void)requestToken
+{
+	/* Try to load an access token from settings */
+	OAToken *atoken = [[OAToken alloc] initWithUserDefaultsUsingServiceProviderName:oauthBase prefix:[@"access:" stringByAppendingString:realm]];
+	if (atoken && [atoken isValid]) {
+		[self setAccessToken:atoken];
+		return;
+	}
+	/* Try to load a stored requestToken from
+	 settings (useful for iPhone) */
+	OAToken *token = [[OAToken alloc] initWithUserDefaultsUsingServiceProviderName:oauthBase prefix:[@"request:" stringByAppendingString:realm]];
+		/* iPhone specific, the manager must have got the authorized token before reaching this point */
+	NSLog(@"request token in settings %@", token);
+	if (token && token.key && [authorizedTokenKey isEqualToString:token.key]) {
+		reqToken = token;
+		[self exchangeToken];
+		return;
+	}
+	if ([delegate respondsToSelector:@selector(tokenManagerNeedsToken:)]) {
+		if (![delegate tokenManagerNeedsToken:self]) {
+			return;
+		}
+	}
+	OACall *call = [[OACall alloc] initWithURL:[NSURL URLWithString:[oauthBase stringByAppendingString:@"request_token"]] method:@"POST"];
+	[call perform:consumer
+			token:initialToken
+			realm:realm
+		 delegate:self
+		didFinish:@selector(requestTokenReceived:body:)];
+	
+}
+
+- (void)requestTokenReceived:(OACall *)call body:(NSString *)body
+{
+	/* XXX: Check if token != nil */
+	NSLog(@"Received request token %@", body);
+	OAToken *token = [[OAToken alloc] initWithHTTPResponseBody:body];
+	if (token) {
+		reqToken = token;
+	
+		[reqToken storeInUserDefaultsWithServiceProviderName:oauthBase prefix:[@"request:" stringByAppendingString:realm]];
+		/* Save the token in case we exit and start again
+		 before the token is authorized (useful for iPhone) */
+//		NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@authorize?oauth_token=%@&oauth_callback=%@",
+//										   oauthBase, token.key, callback]];
+//		[[UIApplication sharedApplication] openURL:url];
+
+	}
+}
+
+// Exchaing a request token for an access token
+
+// Exchanges the current authorized
+// request token for an access token
+- (void)exchangeToken
+{
+	if (!reqToken) {
+		[self requestToken];
+		return;
+	}
+	NSURL *url = [NSURL URLWithString:[oauthBase stringByAppendingString:@"access_token"]];
+	OACall *call = [[OACall alloc] initWithURL:url method:@"POST"];
+	[call perform:consumer
+			token:reqToken
+			realm:realm
+		 delegate:self
+		didFinish:@selector(accessTokenReceived:body:)];
+}
+
+- (void)accessTokenReceived:(OACall *)call body:(NSString *)body
+{
+	OAToken *token = [[OAToken alloc] initWithHTTPResponseBody:body];
+	[self setAccessToken:token];
+}
+
+- (void)renewToken {
+	NSLog(@"Renewing token");
+	if (!acToken || ![acToken isRenewable]) {
+		[self requestToken];
+		return;
+	}
+	acToken.forRenewal = YES;
+	NSURL *url = [NSURL URLWithString:[oauthBase stringByAppendingString:@"access_token"]];
+	OACall *call = [[OACall alloc] initWithURL:url method:@"POST"];
+	[call perform:consumer
+			token:acToken
+			realm:realm
+		 delegate:self
+		didFinish:@selector(accessTokenReceived:body:)];	
+}
+
+- (void)setAccessToken:(OAToken *)token {
+	/* Remove the stored requestToken which generated
+	 this access token */
+	[self deleteSavedRequestToken];
+	if (token) {
+		acToken = token;
+		[acToken storeInUserDefaultsWithServiceProviderName:oauthBase prefix:[@"access:" stringByAppendingString:realm]];
+		@synchronized(self) {
+			isDispatching = NO;
+		}
+		[self dispatch];
+	} else {
+		/* Clear the in-memory and saved access tokens */
+		acToken = nil;
+		[OAToken removeFromUserDefaultsWithServiceProviderName:oauthBase prefix:[@"access:" stringByAppendingString:realm]];
+	}
+}
+
+- (void)deleteSavedRequestToken {
+	[OAToken removeFromUserDefaultsWithServiceProviderName:oauthBase prefix:[@"request:" stringByAppendingString:realm]];
+	reqToken = nil;
+}
+
+- (void)performCall:(OACall *)aCall {
+	NSLog(@"Performing call");
+	[aCall perform:consumer
+			 token:acToken
+			 realm:realm
+		  delegate:self
+		  didFinish:@selector(callFinished:body:)];
+}
+
+- (void)dispatch {
+	OACall *call = [self queue];
+	if (!call) {
+		return;
+	}
+	@synchronized(self) {
+		if (isDispatching) {
+			return;
+		}
+		isDispatching = YES;
+	}
+	NSLog(@"Started dispatching");
+	if(acToken) {
+		[self performCall:call];
+	} else if(reqToken) {
+		[self exchangeToken];
+	} else {
+		[self requestToken];
+	}
+}
+
+- (void)fetchData:(NSString *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters
+			files:(NSDictionary *)theFiles finished:(SEL)didFinish delegate:(NSObject*)aDelegate {
+	
+	OACall *call = [[OACall alloc] initWithURL:[NSURL URLWithString:aURL]
+										method:aMethod
+									parameters:theParameters
+										 files:theFiles];
+	NSLog(@"Received request for: %@", aURL);
+	[self enqueue:call selector:didFinish];
+	if (aDelegate) {
+		[delegates setObject:aDelegate forKey:[NSString stringWithFormat:@"%p", call]];
+	}
+	[self dispatch];
+}
+
+- (void)fetchData:(NSString *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters
+			files:(NSDictionary *)theFiles finished:(SEL)didFinish {
+	
+	[self fetchData:aURL method:aMethod parameters:theParameters files:theFiles
+		   finished:didFinish delegate:nil];
+}
+
+
+- (void)fetchData:(NSString *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters
+		 finished:(SEL)didFinish {
+	
+	[self fetchData:aURL method:aMethod parameters:theParameters files:nil finished:didFinish];
+}
+
+- (void)fetchData:(NSString *)aURL parameters:(NSArray *)theParameters files:(NSDictionary *)theFiles
+		 finished:(SEL)didFinish {
+
+	[self fetchData:aURL method:@"POST" parameters:theParameters files:theFiles finished:didFinish];
+}
+
+- (void)fetchData:(NSString *)aURL finished:(SEL)didFinish {
+	[self fetchData:aURL method:nil parameters:nil files:nil finished:didFinish];
+}
+
+	
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OATokenManager.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OATokenManager.m
@@ -71,7 +71,7 @@
 
 // The application got a new authorized
 // request token and is notifying us
-- (void)authorizedToken:(const NSString *)aKey
+- (void)authorizedToken:(NSString * const)aKey
 {
 	if (reqToken && [aKey isEqualToString:reqToken.key]) {
 		[self exchangeToken];

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAuthConsumer.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/OAuthConsumer/OAuthConsumer.h
@@ -1,0 +1,40 @@
+//
+//  OAuthConsumer.h
+//  OAuthConsumer
+//
+//  Created by Jon Crosby on 10/19/07.
+//  Copyright 2007 Kaboomerang LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "OAProblem.h"
+#import "OAToken.h"
+#import "OAConsumer.h"
+#import "OAMutableURLRequest.h"
+#import "NSString+URLEncoding.h"
+#import "NSMutableURLRequest+Parameters.h"
+#import "NSURL+Base.h"
+#import "OASignatureProviding.h"
+#import "OAHMAC_SHA1SignatureProvider.h"
+#import "OAPlaintextSignatureProvider.h"
+#import "OARequestParameter.h"
+#import "OAServiceTicket.h"
+#import "OADataFetcher.h"
+#import "OATokenManager.h"

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/README
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/README
@@ -1,0 +1,6 @@
+*Please input your own Consumer Key/Secret and Token Key/Secret into YourKeysAndTokens.m before running
+*In a successful case, you should see Yelp JSON data come back and show up in the console
+
+*I'm aware of the numerous leak errors you see above but haven't had the courage to tackle them. Just wanted a version that works with ARC. Do let me know if there are good ways of solving them.
+
+- TB 2014 

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/ViewController.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/ViewController.h
@@ -1,0 +1,16 @@
+//
+//  ViewController.h
+//  YelpAPI-IsolationTestAutoMemory
+//
+//  Created by Terry Bu on 11/7/14.
+//  Copyright (c) 2014 TerryBuOrganization. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController <NSURLConnectionDelegate>
+
+@property (strong, nonatomic) NSMutableData *responseData;
+
+@end
+

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/ViewController.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/ViewController.m
@@ -1,0 +1,106 @@
+//
+//  ViewController.m
+//  YelpAPI-IsolationTestAutoMemory
+//
+//  Created by Terry Bu on 11/7/14.
+//  Copyright (c) 2014 TerryBuOrganization. All rights reserved.
+//
+
+#import "ViewController.h"
+#import "YPAPISample.h"
+#import "OAConsumer.h"
+#import "OAToken.h"
+#import "OAMutableURLRequest.h"
+#import "NSURLRequest+OAuth.h"
+#import "YourKeysAndTokens.h"
+#import <CoreLocation/CoreLocation.h>
+
+
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+    
+    CLGeocoder *geocoder = [[CLGeocoder alloc]init];
+    [geocoder geocodeAddressString:@"Astoria, NY" completionHandler:^(NSArray *placemarks, NSError *error) {
+        if (error) {
+            NSLog(@"%@", error);
+        } else {
+            CLPlacemark *placemark = [placemarks lastObject];
+            NSString *term = @"lunch";
+            NSString *searchLimit= @"10";
+            NSString *address = [[NSString alloc]initWithFormat:@"http://api.yelp.com/v2/search?term=%@&ll=%f,%f&limit=%@", term, placemark.location.coordinate.latitude, placemark.location.coordinate.longitude, searchLimit];
+            
+            NSURL *URL = [NSURL URLWithString:address];
+            //Some boiler plate code to make with OAuth
+            
+            OAConsumer *consumer = [[OAConsumer alloc] initWithKey:kConsumerKey secret:kConsumerSecret]; //Generates the key we pass for OAuth
+            
+            OAToken *token = [[OAToken alloc] initWithKey:kToken secret:kTokenSecret]; //Generates the token we pass for OAuth
+            
+            id<OASignatureProviding, NSObject> provider = [[OAHMAC_SHA1SignatureProvider alloc] init]; //Encypts the key & token to send it over the Internet
+            
+            OAMutableURLRequest *request = [[OAMutableURLRequest alloc] initWithURL:URL consumer:consumer token:token realm:nil signatureProvider:provider]; //Makes the URL request for our url with key, token and other info we set
+            
+            [request prepare]; //OAuth boilerplate
+            
+            self.responseData = [[NSMutableData alloc] init]; //Allocates the NSData object that will handle our asynchronous request
+            
+            NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request delegate:self]; //This is the part we make (fire) url request
+        }
+    }];
+    
+
+    
+
+}
+
+#pragma mark NSURLConnection Delegate Methods
+
+- (void) connection:(NSURLConnection* )connection didReceiveResponse:(NSURLResponse *)response {
+    //this handler, gets hit ONCE
+}
+
+- (void)connection: (NSURLConnection *)connection didReceiveData:(NSData *) data {
+    //this handler, gets hit SEVERAL TIMES
+    [self.responseData appendData:data];
+}
+
+- (NSCachedURLResponse *)connection:(NSURLConnection *)connection willCacheResponse:(NSCachedURLResponse *)cachedResponse {
+    //Return nil to indicate not necessary to store a cached response for this connection
+    return nil;
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
+    //this handler gets hit ONCE
+    // The request is complete and data has been received
+    // You can parse the stuff in your data variable now or do whatever you want
+    
+    NSLog(@"connection finished");
+    NSLog(@"Succeeded! Received %lu bytes of data",(unsigned long)[self.responseData length]);
+    
+    //Convert your responseData object
+    NSError *myError = nil;
+    NSDictionary *responseDataInNSDictionary = [NSJSONSerialization JSONObjectWithData:self.responseData options:NSJSONReadingMutableLeaves error:&myError];
+    
+    NSLog(@"%@", responseDataInNSDictionary);
+}
+
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+
+
+
+
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YPAPISample.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YPAPISample.h
@@ -1,0 +1,30 @@
+//
+//  YPAPISample.h
+//  YelpAPI
+//
+
+#import <Foundation/Foundation.h>
+
+
+
+/**
+ Sample class for accessing the Yelp API V2.
+
+ This class demonstrates the capability of the Yelp API version 2.0 by using the Search API to
+ query for businesses by a search term and location, and the Business API to query additional
+ information about the top result from the search query.
+
+ See the Yelp Documentation http://www.yelp.com/developers/documentation for more info.
+ */
+@interface YPAPISample : NSObject
+
+/**
+ Query the Yelp API with a given term and location and displays the progress in the log
+ 
+ @param term: The term of the search, e.g: dinner
+ @param location: The location in which the term should be searched for, e.g: San Francisco, CA
+ */
+- (void)queryTopBusinessInfoForTerm:(NSString *)term location:(NSString *)location completionHandler:(void (^)(NSDictionary *jsonResponse, NSError *error))completionHandler;
+
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YPAPISample.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YPAPISample.m
@@ -1,0 +1,106 @@
+//
+//  YPAPISample.m
+//  YelpAPI
+
+#import "YPAPISample.h"
+#import "NSURLRequest+OAuth.h"
+#import "YourKeysAndTokens.h"
+
+/**
+ Default paths and search terms used in this example
+ */
+static NSString * const kAPIHost           = @"api.yelp.com";
+static NSString * const kSearchPath        = @"/v2/search/";
+static NSString * const kBusinessPath      = @"/v2/business/";
+static NSString * const kSearchLimit       = @"3";
+
+
+
+@implementation YPAPISample
+
+#pragma mark - Public
+
+- (void)queryTopBusinessInfoForTerm:(NSString *)term location:(NSString *)location completionHandler:(void (^)(NSDictionary *topBusinessJSON, NSError *error))completionHandler {
+
+  NSLog(@"Querying the Search API with term \'%@\' and location \'%@'", term, location);
+
+  //Make a first request to get the search results with the passed term and location
+  NSURLRequest *searchRequest = [self _searchRequestWithTerm:term location:location];
+  NSURLSession *session = [NSURLSession sharedSession];
+  [[session dataTaskWithRequest:searchRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+
+    if (!error && httpResponse.statusCode == 200) {
+
+      NSDictionary *searchResponseJSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+      NSArray *businessArray = searchResponseJSON[@"businesses"];
+
+      if ([businessArray count] > 0) {
+        NSDictionary *firstBusiness = [businessArray firstObject];
+        NSString *firstBusinessID = firstBusiness[@"id"];
+        NSLog(@"%lu businesses found, querying business info for the top result: %@", (unsigned long)[businessArray count], firstBusinessID);
+
+        [self queryBusinessInfoForBusinessId:firstBusinessID completionHandler:completionHandler];
+      } else {
+        completionHandler(nil, error); // No business was found
+      }
+    } else {
+      completionHandler(nil, error); // An error happened or the HTTP response is not a 200 OK
+    }
+  }] resume];
+}
+
+- (void)queryBusinessInfoForBusinessId:(NSString *)businessID completionHandler:(void (^)(NSDictionary *topBusinessJSON, NSError *error))completionHandler {
+
+  NSURLSession *session = [NSURLSession sharedSession];
+  NSURLRequest *businessInfoRequest = [self _businessInfoRequestForID:businessID];
+  [[session dataTaskWithRequest:businessInfoRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+    if (!error && httpResponse.statusCode == 200) {
+      NSDictionary *businessResponseJSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+
+      completionHandler(businessResponseJSON, error);
+    } else {
+      completionHandler(nil, error);
+    }
+  }] resume];
+
+}
+
+
+#pragma mark - API Request Builders
+
+/**
+ Builds a request to hit the search endpoint with the given parameters.
+ 
+ @param term The term of the search, e.g: dinner
+ @param location The location request, e.g: San Francisco, CA
+
+ @return The NSURLRequest needed to perform the search
+ */
+- (NSURLRequest *)_searchRequestWithTerm:(NSString *)term location:(NSString *)location {
+  NSDictionary *params = @{
+                           @"term": term,
+                           @"location": location,
+                           @"limit": kSearchLimit
+                           };
+
+  return [NSURLRequest requestWithHost:kAPIHost path:kSearchPath params:params];
+}
+
+/**
+ Builds a request to hit the business endpoint with the given business ID.
+ 
+ @param businessID The id of the business for which we request informations
+
+ @return The NSURLRequest needed to query the business info
+ */
+- (NSURLRequest *)_businessInfoRequestForID:(NSString *)businessID {
+
+  NSString *businessPath = [NSString stringWithFormat:@"%@%@", kBusinessPath, businessID];
+  return [NSURLRequest requestWithHost:kAPIHost path:businessPath];
+}
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.h
@@ -1,0 +1,18 @@
+//
+//  HideTheseKeys.h
+//  YelpAPI-IsolationTestAutoMemory
+//
+//  Created by Terry Bu on 11/7/14.
+//  Copyright (c) 2014 TerryBuOrganization. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+extern const NSString * kConsumerKey;
+extern const NSString * kConsumerSecret;
+extern const NSString * kToken;
+extern const NSString * kTokenSecret;
+
+@interface YourKeysAndTokens : NSObject
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.h
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.h
@@ -8,10 +8,10 @@
 
 #import <UIKit/UIKit.h>
 
-extern const NSString * kConsumerKey;
-extern const NSString * kConsumerSecret;
-extern const NSString * kToken;
-extern const NSString * kTokenSecret;
+extern NSString* const kConsumerKey;
+extern NSString* const kConsumerSecret;
+extern NSString* const kToken;
+extern NSString* const kTokenSecret;
 
 @interface YourKeysAndTokens : NSObject
 

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.m
@@ -8,10 +8,10 @@
 
 #import "YourKeysAndTokens.h"
 
-const NSString * kConsumerKey       = @"";
-const NSString * kConsumerSecret    = @"";
-const NSString * kToken             = @"";
-const NSString * kTokenSecret       = @"";
+NSString* const kConsumerKey       = @"";
+NSString* const kConsumerSecret    = @"";
+NSString* const kToken             = @"";
+NSString* const kTokenSecret       = @"";
 
 @implementation YourKeysAndTokens
 

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/YourKeysAndTokens.m
@@ -1,0 +1,18 @@
+//
+//  HideTheseKeys.m
+//  YelpAPI-IsolationTestAutoMemory
+//
+//  Created by Terry Bu on 11/7/14.
+//  Copyright (c) 2014 TerryBuOrganization. All rights reserved.
+//
+
+#import "YourKeysAndTokens.h"
+
+const NSString * kConsumerKey       = @"";
+const NSString * kConsumerSecret    = @"";
+const NSString * kToken             = @"";
+const NSString * kTokenSecret       = @"";
+
+@implementation YourKeysAndTokens
+
+@end

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/main.m
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPI-IsolationTestAutoMemory/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  YelpAPI-IsolationTestAutoMemory
+//
+//  Created by Terry Bu on 11/7/14.
+//  Copyright (c) 2014 TerryBuOrganization. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPISampleARCAllowed.xcodeproj/project.pbxproj
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPISampleARCAllowed.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		AAD44F291A0D21E300FDB656 /* OATokenManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F171A0D21E300FDB656 /* OATokenManager.m */; };
 		AAD44F2B1A0D26FE00FDB656 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAD44F2A1A0D26FE00FDB656 /* CoreLocation.framework */; };
 		AAD44F301A0D2E2600FDB656 /* YourKeysAndTokens.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F2F1A0D2E2600FDB656 /* YourKeysAndTokens.m */; };
+		AAD44F321A0D33C800FDB656 /* README in Resources */ = {isa = PBXBuildFile; fileRef = AAD44F311A0D33C800FDB656 /* README */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +91,7 @@
 		AAD44F2A1A0D26FE00FDB656 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		AAD44F2E1A0D2E2600FDB656 /* YourKeysAndTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YourKeysAndTokens.h; sourceTree = "<group>"; };
 		AAD44F2F1A0D2E2600FDB656 /* YourKeysAndTokens.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YourKeysAndTokens.m; sourceTree = "<group>"; };
+		AAD44F311A0D33C800FDB656 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +137,7 @@
 				AAD44ECB1A0D217300FDB656 /* AppDelegate.m */,
 				AAD44ECD1A0D217300FDB656 /* ViewController.h */,
 				AAD44ECE1A0D217300FDB656 /* ViewController.m */,
+				AAD44F311A0D33C800FDB656 /* README */,
 				AAD44ED01A0D217300FDB656 /* Main.storyboard */,
 				AAD44ED31A0D217300FDB656 /* Images.xcassets */,
 				AAD44ED51A0D217300FDB656 /* LaunchScreen.xib */,
@@ -268,6 +271,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD44F321A0D33C800FDB656 /* README in Resources */,
 				AAD44ED21A0D217300FDB656 /* Main.storyboard in Resources */,
 				AAD44ED71A0D217300FDB656 /* LaunchScreen.xib in Resources */,
 				AAD44ED41A0D217300FDB656 /* Images.xcassets in Resources */,

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPISampleARCAllowed.xcodeproj/project.pbxproj
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPISampleARCAllowed.xcodeproj/project.pbxproj
@@ -1,0 +1,454 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AAD44EC91A0D217300FDB656 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EC81A0D217300FDB656 /* main.m */; };
+		AAD44ECC1A0D217300FDB656 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44ECB1A0D217300FDB656 /* AppDelegate.m */; };
+		AAD44ECF1A0D217300FDB656 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44ECE1A0D217300FDB656 /* ViewController.m */; };
+		AAD44ED21A0D217300FDB656 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AAD44ED01A0D217300FDB656 /* Main.storyboard */; };
+		AAD44ED41A0D217300FDB656 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAD44ED31A0D217300FDB656 /* Images.xcassets */; };
+		AAD44ED71A0D217300FDB656 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = AAD44ED51A0D217300FDB656 /* LaunchScreen.xib */; };
+		AAD44EF01A0D218200FDB656 /* NSURLRequest+OAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EED1A0D218200FDB656 /* NSURLRequest+OAuth.m */; };
+		AAD44EF11A0D218200FDB656 /* YPAPISample.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EEF1A0D218200FDB656 /* YPAPISample.m */; };
+		AAD44F191A0D21E300FDB656 /* NSMutableURLRequest+Parameters.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EF51A0D21E300FDB656 /* NSMutableURLRequest+Parameters.m */; };
+		AAD44F1A1A0D21E300FDB656 /* NSString+URLEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EF71A0D21E300FDB656 /* NSString+URLEncoding.m */; };
+		AAD44F1B1A0D21E300FDB656 /* NSURL+Base.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EF91A0D21E300FDB656 /* NSURL+Base.m */; };
+		AAD44F1C1A0D21E300FDB656 /* Base64Transcoder.c in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EFB1A0D21E300FDB656 /* Base64Transcoder.c */; };
+		AAD44F1D1A0D21E300FDB656 /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EFD1A0D21E300FDB656 /* hmac.c */; };
+		AAD44F1E1A0D21E300FDB656 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = AAD44EFF1A0D21E300FDB656 /* sha1.c */; };
+		AAD44F1F1A0D21E300FDB656 /* OACall.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F021A0D21E300FDB656 /* OACall.m */; };
+		AAD44F201A0D21E300FDB656 /* OAConsumer.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F041A0D21E300FDB656 /* OAConsumer.m */; };
+		AAD44F211A0D21E300FDB656 /* OADataFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F061A0D21E300FDB656 /* OADataFetcher.m */; };
+		AAD44F221A0D21E300FDB656 /* OAHMAC_SHA1SignatureProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F081A0D21E300FDB656 /* OAHMAC_SHA1SignatureProvider.m */; };
+		AAD44F231A0D21E300FDB656 /* OAMutableURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F0A1A0D21E300FDB656 /* OAMutableURLRequest.m */; };
+		AAD44F241A0D21E300FDB656 /* OAPlaintextSignatureProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F0C1A0D21E300FDB656 /* OAPlaintextSignatureProvider.m */; };
+		AAD44F251A0D21E300FDB656 /* OAProblem.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F0E1A0D21E300FDB656 /* OAProblem.m */; };
+		AAD44F261A0D21E300FDB656 /* OARequestParameter.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F101A0D21E300FDB656 /* OARequestParameter.m */; };
+		AAD44F271A0D21E300FDB656 /* OAServiceTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F121A0D21E300FDB656 /* OAServiceTicket.m */; };
+		AAD44F281A0D21E300FDB656 /* OAToken.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F151A0D21E300FDB656 /* OAToken.m */; };
+		AAD44F291A0D21E300FDB656 /* OATokenManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F171A0D21E300FDB656 /* OATokenManager.m */; };
+		AAD44F2B1A0D26FE00FDB656 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAD44F2A1A0D26FE00FDB656 /* CoreLocation.framework */; };
+		AAD44F301A0D2E2600FDB656 /* YourKeysAndTokens.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD44F2F1A0D2E2600FDB656 /* YourKeysAndTokens.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		AAD44EC31A0D217300FDB656 /* YelpAPISampleARCAllowed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YelpAPISampleARCAllowed.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAD44EC71A0D217300FDB656 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AAD44EC81A0D217300FDB656 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		AAD44ECA1A0D217300FDB656 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		AAD44ECB1A0D217300FDB656 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		AAD44ECD1A0D217300FDB656 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		AAD44ECE1A0D217300FDB656 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		AAD44ED11A0D217300FDB656 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		AAD44ED31A0D217300FDB656 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		AAD44ED61A0D217300FDB656 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		AAD44EEC1A0D218200FDB656 /* NSURLRequest+OAuth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLRequest+OAuth.h"; sourceTree = "<group>"; };
+		AAD44EED1A0D218200FDB656 /* NSURLRequest+OAuth.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLRequest+OAuth.m"; sourceTree = "<group>"; };
+		AAD44EEE1A0D218200FDB656 /* YPAPISample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YPAPISample.h; sourceTree = "<group>"; };
+		AAD44EEF1A0D218200FDB656 /* YPAPISample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YPAPISample.m; sourceTree = "<group>"; };
+		AAD44EF41A0D21E300FDB656 /* NSMutableURLRequest+Parameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Parameters.h"; sourceTree = "<group>"; };
+		AAD44EF51A0D21E300FDB656 /* NSMutableURLRequest+Parameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+Parameters.m"; sourceTree = "<group>"; };
+		AAD44EF61A0D21E300FDB656 /* NSString+URLEncoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+URLEncoding.h"; sourceTree = "<group>"; };
+		AAD44EF71A0D21E300FDB656 /* NSString+URLEncoding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+URLEncoding.m"; sourceTree = "<group>"; };
+		AAD44EF81A0D21E300FDB656 /* NSURL+Base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+Base.h"; sourceTree = "<group>"; };
+		AAD44EF91A0D21E300FDB656 /* NSURL+Base.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+Base.m"; sourceTree = "<group>"; };
+		AAD44EFB1A0D21E300FDB656 /* Base64Transcoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = Base64Transcoder.c; sourceTree = "<group>"; };
+		AAD44EFC1A0D21E300FDB656 /* Base64Transcoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Base64Transcoder.h; sourceTree = "<group>"; };
+		AAD44EFD1A0D21E300FDB656 /* hmac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac.c; sourceTree = "<group>"; };
+		AAD44EFE1A0D21E300FDB656 /* hmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hmac.h; sourceTree = "<group>"; };
+		AAD44EFF1A0D21E300FDB656 /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
+		AAD44F001A0D21E300FDB656 /* sha1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha1.h; sourceTree = "<group>"; };
+		AAD44F011A0D21E300FDB656 /* OACall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OACall.h; sourceTree = "<group>"; };
+		AAD44F021A0D21E300FDB656 /* OACall.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OACall.m; sourceTree = "<group>"; };
+		AAD44F031A0D21E300FDB656 /* OAConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAConsumer.h; sourceTree = "<group>"; };
+		AAD44F041A0D21E300FDB656 /* OAConsumer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAConsumer.m; sourceTree = "<group>"; };
+		AAD44F051A0D21E300FDB656 /* OADataFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OADataFetcher.h; sourceTree = "<group>"; };
+		AAD44F061A0D21E300FDB656 /* OADataFetcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OADataFetcher.m; sourceTree = "<group>"; };
+		AAD44F071A0D21E300FDB656 /* OAHMAC_SHA1SignatureProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAHMAC_SHA1SignatureProvider.h; sourceTree = "<group>"; };
+		AAD44F081A0D21E300FDB656 /* OAHMAC_SHA1SignatureProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAHMAC_SHA1SignatureProvider.m; sourceTree = "<group>"; };
+		AAD44F091A0D21E300FDB656 /* OAMutableURLRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAMutableURLRequest.h; sourceTree = "<group>"; };
+		AAD44F0A1A0D21E300FDB656 /* OAMutableURLRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAMutableURLRequest.m; sourceTree = "<group>"; };
+		AAD44F0B1A0D21E300FDB656 /* OAPlaintextSignatureProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAPlaintextSignatureProvider.h; sourceTree = "<group>"; };
+		AAD44F0C1A0D21E300FDB656 /* OAPlaintextSignatureProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAPlaintextSignatureProvider.m; sourceTree = "<group>"; };
+		AAD44F0D1A0D21E300FDB656 /* OAProblem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAProblem.h; sourceTree = "<group>"; };
+		AAD44F0E1A0D21E300FDB656 /* OAProblem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAProblem.m; sourceTree = "<group>"; };
+		AAD44F0F1A0D21E300FDB656 /* OARequestParameter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OARequestParameter.h; sourceTree = "<group>"; };
+		AAD44F101A0D21E300FDB656 /* OARequestParameter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OARequestParameter.m; sourceTree = "<group>"; };
+		AAD44F111A0D21E300FDB656 /* OAServiceTicket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAServiceTicket.h; sourceTree = "<group>"; };
+		AAD44F121A0D21E300FDB656 /* OAServiceTicket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAServiceTicket.m; sourceTree = "<group>"; };
+		AAD44F131A0D21E300FDB656 /* OASignatureProviding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OASignatureProviding.h; sourceTree = "<group>"; };
+		AAD44F141A0D21E300FDB656 /* OAToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAToken.h; sourceTree = "<group>"; };
+		AAD44F151A0D21E300FDB656 /* OAToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAToken.m; sourceTree = "<group>"; };
+		AAD44F161A0D21E300FDB656 /* OATokenManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OATokenManager.h; sourceTree = "<group>"; };
+		AAD44F171A0D21E300FDB656 /* OATokenManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OATokenManager.m; sourceTree = "<group>"; };
+		AAD44F181A0D21E300FDB656 /* OAuthConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAuthConsumer.h; sourceTree = "<group>"; };
+		AAD44F2A1A0D26FE00FDB656 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		AAD44F2E1A0D2E2600FDB656 /* YourKeysAndTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YourKeysAndTokens.h; sourceTree = "<group>"; };
+		AAD44F2F1A0D2E2600FDB656 /* YourKeysAndTokens.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YourKeysAndTokens.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AAD44EC01A0D217300FDB656 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AAD44F2B1A0D26FE00FDB656 /* CoreLocation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AAD44EBA1A0D217300FDB656 = {
+			isa = PBXGroup;
+			children = (
+				AAD44F2A1A0D26FE00FDB656 /* CoreLocation.framework */,
+				AAD44EC51A0D217300FDB656 /* YelpAPI-IsolationTestAutoMemory */,
+				AAD44EC41A0D217300FDB656 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AAD44EC41A0D217300FDB656 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AAD44EC31A0D217300FDB656 /* YelpAPISampleARCAllowed.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AAD44EC51A0D217300FDB656 /* YelpAPI-IsolationTestAutoMemory */ = {
+			isa = PBXGroup;
+			children = (
+				AAD44EF21A0D21E300FDB656 /* OAuthConsumer */,
+				AAD44EEC1A0D218200FDB656 /* NSURLRequest+OAuth.h */,
+				AAD44EED1A0D218200FDB656 /* NSURLRequest+OAuth.m */,
+				AAD44F2E1A0D2E2600FDB656 /* YourKeysAndTokens.h */,
+				AAD44F2F1A0D2E2600FDB656 /* YourKeysAndTokens.m */,
+				AAD44EEE1A0D218200FDB656 /* YPAPISample.h */,
+				AAD44EEF1A0D218200FDB656 /* YPAPISample.m */,
+				AAD44ECA1A0D217300FDB656 /* AppDelegate.h */,
+				AAD44ECB1A0D217300FDB656 /* AppDelegate.m */,
+				AAD44ECD1A0D217300FDB656 /* ViewController.h */,
+				AAD44ECE1A0D217300FDB656 /* ViewController.m */,
+				AAD44ED01A0D217300FDB656 /* Main.storyboard */,
+				AAD44ED31A0D217300FDB656 /* Images.xcassets */,
+				AAD44ED51A0D217300FDB656 /* LaunchScreen.xib */,
+				AAD44EC61A0D217300FDB656 /* Supporting Files */,
+			);
+			path = "YelpAPI-IsolationTestAutoMemory";
+			sourceTree = "<group>";
+		};
+		AAD44EC61A0D217300FDB656 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				AAD44EC71A0D217300FDB656 /* Info.plist */,
+				AAD44EC81A0D217300FDB656 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		AAD44EF21A0D21E300FDB656 /* OAuthConsumer */ = {
+			isa = PBXGroup;
+			children = (
+				AAD44EF31A0D21E300FDB656 /* Categories */,
+				AAD44EFA1A0D21E300FDB656 /* Crytpo */,
+				AAD44F011A0D21E300FDB656 /* OACall.h */,
+				AAD44F021A0D21E300FDB656 /* OACall.m */,
+				AAD44F031A0D21E300FDB656 /* OAConsumer.h */,
+				AAD44F041A0D21E300FDB656 /* OAConsumer.m */,
+				AAD44F051A0D21E300FDB656 /* OADataFetcher.h */,
+				AAD44F061A0D21E300FDB656 /* OADataFetcher.m */,
+				AAD44F071A0D21E300FDB656 /* OAHMAC_SHA1SignatureProvider.h */,
+				AAD44F081A0D21E300FDB656 /* OAHMAC_SHA1SignatureProvider.m */,
+				AAD44F091A0D21E300FDB656 /* OAMutableURLRequest.h */,
+				AAD44F0A1A0D21E300FDB656 /* OAMutableURLRequest.m */,
+				AAD44F0B1A0D21E300FDB656 /* OAPlaintextSignatureProvider.h */,
+				AAD44F0C1A0D21E300FDB656 /* OAPlaintextSignatureProvider.m */,
+				AAD44F0D1A0D21E300FDB656 /* OAProblem.h */,
+				AAD44F0E1A0D21E300FDB656 /* OAProblem.m */,
+				AAD44F0F1A0D21E300FDB656 /* OARequestParameter.h */,
+				AAD44F101A0D21E300FDB656 /* OARequestParameter.m */,
+				AAD44F111A0D21E300FDB656 /* OAServiceTicket.h */,
+				AAD44F121A0D21E300FDB656 /* OAServiceTicket.m */,
+				AAD44F131A0D21E300FDB656 /* OASignatureProviding.h */,
+				AAD44F141A0D21E300FDB656 /* OAToken.h */,
+				AAD44F151A0D21E300FDB656 /* OAToken.m */,
+				AAD44F161A0D21E300FDB656 /* OATokenManager.h */,
+				AAD44F171A0D21E300FDB656 /* OATokenManager.m */,
+				AAD44F181A0D21E300FDB656 /* OAuthConsumer.h */,
+			);
+			path = OAuthConsumer;
+			sourceTree = "<group>";
+		};
+		AAD44EF31A0D21E300FDB656 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				AAD44EF41A0D21E300FDB656 /* NSMutableURLRequest+Parameters.h */,
+				AAD44EF51A0D21E300FDB656 /* NSMutableURLRequest+Parameters.m */,
+				AAD44EF61A0D21E300FDB656 /* NSString+URLEncoding.h */,
+				AAD44EF71A0D21E300FDB656 /* NSString+URLEncoding.m */,
+				AAD44EF81A0D21E300FDB656 /* NSURL+Base.h */,
+				AAD44EF91A0D21E300FDB656 /* NSURL+Base.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		AAD44EFA1A0D21E300FDB656 /* Crytpo */ = {
+			isa = PBXGroup;
+			children = (
+				AAD44EFB1A0D21E300FDB656 /* Base64Transcoder.c */,
+				AAD44EFC1A0D21E300FDB656 /* Base64Transcoder.h */,
+				AAD44EFD1A0D21E300FDB656 /* hmac.c */,
+				AAD44EFE1A0D21E300FDB656 /* hmac.h */,
+				AAD44EFF1A0D21E300FDB656 /* sha1.c */,
+				AAD44F001A0D21E300FDB656 /* sha1.h */,
+			);
+			path = Crytpo;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AAD44EC21A0D217300FDB656 /* YelpAPISampleARCAllowed */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AAD44EE61A0D217300FDB656 /* Build configuration list for PBXNativeTarget "YelpAPISampleARCAllowed" */;
+			buildPhases = (
+				AAD44EBF1A0D217300FDB656 /* Sources */,
+				AAD44EC01A0D217300FDB656 /* Frameworks */,
+				AAD44EC11A0D217300FDB656 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = YelpAPISampleARCAllowed;
+			productName = "YelpAPI-IsolationTestAutoMemory";
+			productReference = AAD44EC31A0D217300FDB656 /* YelpAPISampleARCAllowed.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AAD44EBB1A0D217300FDB656 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = TerryBuOrganization;
+				TargetAttributes = {
+					AAD44EC21A0D217300FDB656 = {
+						CreatedOnToolsVersion = 6.1;
+					};
+				};
+			};
+			buildConfigurationList = AAD44EBE1A0D217300FDB656 /* Build configuration list for PBXProject "YelpAPISampleARCAllowed" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AAD44EBA1A0D217300FDB656;
+			productRefGroup = AAD44EC41A0D217300FDB656 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AAD44EC21A0D217300FDB656 /* YelpAPISampleARCAllowed */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AAD44EC11A0D217300FDB656 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AAD44ED21A0D217300FDB656 /* Main.storyboard in Resources */,
+				AAD44ED71A0D217300FDB656 /* LaunchScreen.xib in Resources */,
+				AAD44ED41A0D217300FDB656 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AAD44EBF1A0D217300FDB656 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AAD44F1D1A0D21E300FDB656 /* hmac.c in Sources */,
+				AAD44EF01A0D218200FDB656 /* NSURLRequest+OAuth.m in Sources */,
+				AAD44F1B1A0D21E300FDB656 /* NSURL+Base.m in Sources */,
+				AAD44F211A0D21E300FDB656 /* OADataFetcher.m in Sources */,
+				AAD44F301A0D2E2600FDB656 /* YourKeysAndTokens.m in Sources */,
+				AAD44EF11A0D218200FDB656 /* YPAPISample.m in Sources */,
+				AAD44F291A0D21E300FDB656 /* OATokenManager.m in Sources */,
+				AAD44F271A0D21E300FDB656 /* OAServiceTicket.m in Sources */,
+				AAD44F281A0D21E300FDB656 /* OAToken.m in Sources */,
+				AAD44F251A0D21E300FDB656 /* OAProblem.m in Sources */,
+				AAD44ECF1A0D217300FDB656 /* ViewController.m in Sources */,
+				AAD44F241A0D21E300FDB656 /* OAPlaintextSignatureProvider.m in Sources */,
+				AAD44F261A0D21E300FDB656 /* OARequestParameter.m in Sources */,
+				AAD44F231A0D21E300FDB656 /* OAMutableURLRequest.m in Sources */,
+				AAD44ECC1A0D217300FDB656 /* AppDelegate.m in Sources */,
+				AAD44F1E1A0D21E300FDB656 /* sha1.c in Sources */,
+				AAD44F191A0D21E300FDB656 /* NSMutableURLRequest+Parameters.m in Sources */,
+				AAD44F1A1A0D21E300FDB656 /* NSString+URLEncoding.m in Sources */,
+				AAD44F1C1A0D21E300FDB656 /* Base64Transcoder.c in Sources */,
+				AAD44F201A0D21E300FDB656 /* OAConsumer.m in Sources */,
+				AAD44EC91A0D217300FDB656 /* main.m in Sources */,
+				AAD44F1F1A0D21E300FDB656 /* OACall.m in Sources */,
+				AAD44F221A0D21E300FDB656 /* OAHMAC_SHA1SignatureProvider.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		AAD44ED01A0D217300FDB656 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AAD44ED11A0D217300FDB656 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		AAD44ED51A0D217300FDB656 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AAD44ED61A0D217300FDB656 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		AAD44EE41A0D217300FDB656 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AAD44EE51A0D217300FDB656 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AAD44EE71A0D217300FDB656 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "YelpAPI-IsolationTestAutoMemory/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = YelpAPISampleARCAllowed;
+			};
+			name = Debug;
+		};
+		AAD44EE81A0D217300FDB656 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "YelpAPI-IsolationTestAutoMemory/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = YelpAPISampleARCAllowed;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AAD44EBE1A0D217300FDB656 /* Build configuration list for PBXProject "YelpAPISampleARCAllowed" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AAD44EE41A0D217300FDB656 /* Debug */,
+				AAD44EE51A0D217300FDB656 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AAD44EE61A0D217300FDB656 /* Build configuration list for PBXNativeTarget "YelpAPISampleARCAllowed" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AAD44EE71A0D217300FDB656 /* Debug */,
+				AAD44EE81A0D217300FDB656 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AAD44EBB1A0D217300FDB656 /* Project object */;
+}

--- a/v2/objective-c/YelpAPISampleARCAllowed/YelpAPISampleARCAllowed.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/v2/objective-c/YelpAPISampleARCAllowed/YelpAPISampleARCAllowed.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:YelpAPISampleARCAllowed.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
Thanks for this great API. Without it, I would not have been able to figure out how to work with Yelp API at all!

Due to Manual memory management (with release, dealloc and autorelease) in the previous version, it wasn't able to be neatly integrated into newer apps that use ARC in XCode. So I just deleted out some code and made a new folder under v2 - objective -c with name "YelpAPISampleARCAllowed". It still prompts a lot of errors in XCode (possibility memory leaks here and there) but it doesn't look too bad and now, it works well with ARC projects.

Thank you, TB 