### PR TITLE
Convert all examples to use HTTPS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 *.pbxuser
 *.mode1v3
 .DS_Store
+.ropeproject

--- a/v2/csharp/YelpAPI/Program.cs
+++ b/v2/csharp/YelpAPI/Program.cs
@@ -56,7 +56,7 @@ namespace YelpAPI
         /// <summary>
         /// Host of the API.
         /// </summary>
-        private const string API_HOST = "http://api.yelp.com";
+        private const string API_HOST = "https://api.yelp.com";
 
         /// <summary>
         /// Relative path for the Search API.

--- a/v2/java/YelpAPI.java
+++ b/v2/java/YelpAPI.java
@@ -98,7 +98,7 @@ public class YelpAPI {
    * @return <tt>OAuthRequest</tt>
    */
   private OAuthRequest createOAuthRequest(String path) {
-    OAuthRequest request = new OAuthRequest(Verb.GET, "http://" + API_HOST + path);
+    OAuthRequest request = new OAuthRequest(Verb.GET, "https://" + API_HOST + path);
     return request;
   }
 

--- a/v2/objective-c/YelpAPISample/NSURLRequest+OAuth.m
+++ b/v2/objective-c/YelpAPISample/NSURLRequest+OAuth.m
@@ -62,7 +62,7 @@ static NSString * const kTokenSecret       = @"";
   }
 
   NSURLComponents *components = [[NSURLComponents alloc] init];
-  components.scheme = @"http";
+  components.scheme = @"https";
   components.host = host;
   components.path = path;
   components.query = [queryParts componentsJoinedByString:@"&"];

--- a/v2/perl/search.pl
+++ b/v2/perl/search.pl
@@ -9,13 +9,14 @@ use Net::OAuth;
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0;
 use HTTP::Request::Common;
 my $ua = LWP::UserAgent->new;
+use Mozilla::CA;
 
 sub consumer_key { 'insert consumer key here' }
 sub consumer_secret { 'insert consumer secret here' }
 sub access_token { 'insert access token here' }
 sub access_token_secret { 'insert access token secret here' }
 
-sub user_url { 'http://api.yelp.com/v2/search?term=food&location=San+Francisco' }
+sub user_url { 'https://api.yelp.com/v2/search?term=food&location=San+Francisco' }
 
 my $request =
         Net::OAuth->request('protected resource')->new(

--- a/v2/php/sample.php
+++ b/v2/php/sample.php
@@ -47,7 +47,7 @@ $BUSINESS_PATH = '/v2/business/';
  * @return   The JSON response from the request      
  */
 function request($host, $path) {
-    $unsigned_url = "http://" . $host . $path;
+    $unsigned_url = "https://" . $host . $path;
 
     // Token object built using the OAuth library
     $token = new OAuthToken($GLOBALS['TOKEN'], $GLOBALS['TOKEN_SECRET']);

--- a/v2/python/sample.py
+++ b/v2/python/sample.py
@@ -54,7 +54,7 @@ def request(host, path, url_params=None):
         urllib2.HTTPError: An error occurs from the HTTP request.
     """
     url_params = url_params or {}
-    url = 'http://{0}{1}?'.format(host, urllib.quote(path.encode('utf8')))
+    url = 'https://{0}{1}?'.format(host, urllib.quote(path.encode('utf8')))
 
     consumer = oauth2.Consumer(CONSUMER_KEY, CONSUMER_SECRET)
     oauth_request = oauth2.Request(method="GET", url=url, parameters=url_params)


### PR DESCRIPTION
Upgrade the last two "http" examples to use https.  For Perl, this adds a dependency on a `Mozilla::CA` cert package; tried to make that clear by `use`-ing it.

Ran both examples locally with my own creds; both still pass.

Closes #55 .