### PR TITLE
adds support for unicode business_ids in python api

### DIFF
--- a/v2/python/sample.py
+++ b/v2/python/sample.py
@@ -23,6 +23,10 @@ import urllib
 import urllib2
 
 import oauth2
+import sys
+
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 
 API_HOST = 'api.yelp.com'


### PR DESCRIPTION
Before this change non-ascii business_ids were not supported.
This change adds support for unicode business_ids in  the python api.