### PR TITLE
Fix C# typo in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the official Ruby client library, we have [yelp-ruby](https://github.com/yel
 
 Please note that we do not provide support for any of the unofficial libraries, these are provided to you as-is. If you have any problems with them, please open an issue on the project itself.
 
-#### C\#
+#### C#
 
 [yelpsharp](https://github.com/JustinBeckwith/yelpsharp)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the official Ruby client library, we have [yelp-ruby](https://github.com/yel
 
 Please note that we do not provide support for any of the unofficial libraries, these are provided to you as-is. If you have any problems with them, please open an issue on the project itself.
 
-#### C#
+#### C# ####
 
 [yelpsharp](https://github.com/JustinBeckwith/yelpsharp)
 


### PR DESCRIPTION
The hash in "C#" is getting interpreted as "closing" the heading markup.  Add an actual heading-closing instead.

Not bothering with the other headers.

Closes #89.