### PR TITLE
PHP example should show diagnostics when curl fails.  Refs #102.

### DIFF
--- a/v2/php/sample.php
+++ b/v2/php/sample.php
@@ -84,7 +84,7 @@ function request($host, $path) {
             throw new Exception(curl_error($ch), curl_errno($ch));
         $http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if (200 != $http_status)
-            throw new Exception("HTTP Status was not SUCCESS", $http_status);
+            throw new Exception($data, $http_status);
 
         curl_close($ch);
     } catch(Exception $e) {

--- a/v2/php/sample.php
+++ b/v2/php/sample.php
@@ -72,11 +72,27 @@ function request($host, $path) {
     $signed_url = $oauthrequest->to_url();
     
     // Send Yelp API Call
-    $ch = curl_init($signed_url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HEADER, 0);
-    $data = curl_exec($ch);
-    curl_close($ch);
+    try {
+        $ch = curl_init($signed_url);
+        if (FALSE === $ch)
+            throw new Exception('Failed to initialize');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        $data = curl_exec($ch);
+
+        if (FALSE === $data)
+            throw new Exception(curl_error($ch), curl_errno($ch));
+        $http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if (200 != $http_status)
+            throw new Exception("HTTP Status was not SUCCESS", $http_status);
+
+        curl_close($ch);
+    } catch(Exception $e) {
+        trigger_error(sprintf(
+            'Curl failed with error #%d: %s',
+            $e->getCode(), $e->getMessage()),
+            E_USER_ERROR);
+    }
     
     return $data;
 }


### PR DESCRIPTION
Added http://stackoverflow.com/questions/8227909/curl-exec-always-returns-false and some HTTP error code checking.

Success case still works.

Example 403 with no creds before, note `/search` hits confusing undefined properties (though `/business` shows the error):
```
$ php sample.php --term="bars" --location="sf" 
PHP Notice:  Undefined property: stdClass::$businesses in /nail/home/kmitton/pg/other/yelp-api/v2/php/sample.php on line 122
PHP Notice:  Trying to get property of non-object in /nail/home/kmitton/pg/other/yelp-api/v2/php/sample.php on line 122
PHP Notice:  Undefined property: stdClass::$businesses in /nail/home/kmitton/pg/other/yelp-api/v2/php/sample.php on line 126
0 businesses found, querying business info for the top result ""

Result for business "" found:
{"error": {"text": "The OAuth credentials are invalid", "id": "INVALID_OAUTH_CREDENTIALS"}}
```

After, note HTTP status code and cleaner failure:
```
$ php sample.php --term="bars" --location="sf" 
PHP Fatal error:  Curl failed with error #403: {"error": {"text": "The OAuth credentials are invalid", "id": "INVALID_OAUTH_CREDENTIALS"}} in /nail/home/kmitton/pg/other/yelp-api/v2/php/sample.php on line 94
```

This also covers lower-level curl errors like failed connections, see #101 .