### PR TITLE
PHP example should URL-encode business IDs used in /v2/business path.  Closes #118.

### DIFF
--- a/v2/php/sample.php
+++ b/v2/php/sample.php
@@ -122,7 +122,7 @@ function search($term, $location) {
  * @return   The JSON response from the request 
  */
 function get_business($business_id) {
-    $business_path = $GLOBALS['BUSINESS_PATH'] . $business_id;
+    $business_path = $GLOBALS['BUSINESS_PATH'] . urlencode($business_id);
     
     return request($GLOBALS['API_HOST'], $business_path);
 }


### PR DESCRIPTION
Calling `print get_business('la-fusión-san-francisco-2')` before:
```
PHP Fatal error:  Curl failed with error #400: {"error": {"text": "Signature was invalid", "id": "INVALID_SIGNATURE", "description": "Invalid signature. Expected signature base string: GET\u0026https%3A%2F%2Fapi.yelp.com%2Fv2%2Fbusiness%2Fla-fusi%25C3%25B3n-san-francisco-2\u0026oauth_consumer_key%3DsWc_ig2aihT0s-6Yf-zGIQ%26oauth_nonce%3D34b42ebffd71df54c5fadf22b6368cd3%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1458326155%26oauth_token%3DTu7Aj3WBM2cIA1uurCEyRq7W9ykKbQQy%26oauth_version%3D1.0"}} in /nail/home/kmitton/pg/other/yelp-api/v2/php/sample.php on line 94
```
After:
```
{"is_claimed": true, "rating": 4.5, "mobile_url": "http://m.yelp.com/biz/la-fusi%C3%B3n-san-francisco-2...
```