### PR TITLE
Add unofficial PHP library

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Please note that we do not provide support for any of the unofficial libraries, 
 
 [node-yelp](https://github.com/olalonde/node-yelp)
 
+#### PHP
+
+[yelp-php](https://github.com/stevenmaguire/yelp-php)
+
 #### Swift
 
 [ios_yelp_swift](https://github.com/codepath/ios_yelp_swift)


### PR DESCRIPTION
Greetings! I maintain a well tested PHP package that wraps the Yelp API. It has current support of the v2 Fusion API. I would like to add it to the list of packages that are present in this repo. 

Additionally, purely as an FYI, I also maintain the Yelp OAuth2 php package that facilitates authenticated requests to the Yelp API. https://github.com/stevenmaguire/oauth2-yelp